### PR TITLE
Applying -moz-box-sizing to search box

### DIFF
--- a/app/assets/stylesheets/modules/site_search.css.scss
+++ b/app/assets/stylesheets/modules/site_search.css.scss
@@ -1,6 +1,7 @@
 .search-form {
   .search-query,
   .search-submit {
+    -moz-box-sizing: border-box;
     box-sizing:border-box;
   }
 


### PR DESCRIPTION
Without hte -moz-box-sizing, in Firefox, the search input and search
button were rendering on different lines. This CSS declaration corrects
that.

IDR-152 #resolve
