### PR TITLE
User#sign_in_count matters when visiting dashboard

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
   factory :user do
     sequence(:email) {|n| "email-#{n}@test.com" }
     agreed_to_terms_of_service true
+    sign_in_count 20
   end
 end


### PR DESCRIPTION
Addresses changes from SHA1: 30802b5141330b0e3a4bdb04bde34631a0a01d14
