### PR TITLE
Updating interface for embargo

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,7 +76,11 @@ module ApplicationHelper
     dom_label_class, link_title = "label-important", "Private"
     if hash['read_access_group_t'].present?
       if hash['read_access_group_t'].include?('public')
-        dom_label_class, link_title = 'label-success', 'Open Access'
+        if hash['embargo_release_date_dt'].present?
+          dom_label_class, link_title = 'label-info', 'Open Access with Embargo'
+        else
+          dom_label_class, link_title = 'label-success', 'Open Access'
+        end
       elsif hash['read_access_group_t'].include?('registered')
         dom_label_class, link_title = "label-info", t('sufia.institution_name')
       end

--- a/app/models/access_right.rb
+++ b/app/models/access_right.rb
@@ -4,6 +4,7 @@ class AccessRight
   PERMISSION_TEXT_VALUE_PUBLIC = 'public'.freeze
   PERMISSION_TEXT_VALUE_AUTHENTICATED = 'registered'.freeze
   VISIBILITY_TEXT_VALUE_PUBLIC = 'open'.freeze
+  VISIBILITY_TEXT_VALUE_EMBARGO = 'open_with_embargo_release_date'.freeze
   VISIBILITY_TEXT_VALUE_AUTHENTICATED = 'psu'.freeze
   VISIBILITY_TEXT_VALUE_PRIVATE = 'restricted'.freeze
 
@@ -26,11 +27,17 @@ class AccessRight
 
   def open_access?
     return true if has_visibility_text_for?(VISIBILITY_TEXT_VALUE_PUBLIC)
-    if persisted?
-      has_permission_text_for?(PERMISSION_TEXT_VALUE_PUBLIC)
-    else
-      visibility.to_s == ''
-    end
+    # We don't want to know if its under embargo, simply does it have a date.
+    # In this way, we can properly inform the label input
+    persisted_open_access_permission? && !permissionable.embargo_release_date.present?
+  end
+
+  def open_access_with_embargo_release_date?
+    return false unless permissionable_is_embargoable?
+    return true if has_visibility_text_for?(VISIBILITY_TEXT_VALUE_EMBARGO)
+    # We don't want to know if its under embargo, simply does it have a date.
+    # In this way, we can properly inform the label input
+    persisted_open_access_permission? && permissionable.embargo_release_date.present?
   end
 
   def authenticated_only?
@@ -40,10 +47,31 @@ class AccessRight
   end
 
   def private?
-    !open_access? && !authenticated_only?
+    return false if open_access?
+    return false if authenticated_only?
+    return false if open_access_with_embargo_release_date?
+    true
   end
 
   private
+
+  def persisted_open_access_permission?
+    if persisted?
+      has_permission_text_for?(PERMISSION_TEXT_VALUE_PUBLIC)
+    else
+      visibility.to_s == ''
+    end
+  end
+
+  def on_or_after_any_embargo_release_date?
+    return true unless permissionable.embargo_release_date
+    permissionable.embargo_release_date.to_date < Date.today
+  end
+
+  def permissionable_is_embargoable?
+    permissionable.respond_to?(:embargo_release_date)
+  end
+
   def has_visibility_text_for?(text)
     visibility == text
   end

--- a/app/repository_models/curation_concern/with_access_right.rb
+++ b/app/repository_models/curation_concern/with_access_right.rb
@@ -14,6 +14,10 @@ module CurationConcern
       access_rights.open_access?
     end
 
+    def open_access_with_embargo_release_date?
+      access_rights.open_access_with_embargo_release_date?
+    end
+
     def authenticated_only_access?
       access_rights.authenticated_only?
     end

--- a/app/views/curation_concern/_permission.html.erb
+++ b/app/views/curation_concern/_permission.html.erb
@@ -1,17 +1,6 @@
 <div id="permissions_display">
   <fieldset class="control-group">
     <legend>
-      Embargo Date
-      <small>When to release it for public viewing</small>
-    </legend>
-    <p class="help-block">
-      Need to provide some help text
-    </p>
-    <%= f.input :embargo_release_date, as: :string, input_html: { class: 'datepicker' } %>
-  </fieldset>
-
-  <fieldset class="control-group">
-    <legend>
       Access Rights
       <small>Applied to the attached files and their metadata</small>
     </legend>
@@ -26,6 +15,10 @@
         <span class="label label-success">Open Access</span> Visible to the world.
       </label>
       <label class="radio">
+        <input type="radio" id="visibility_embargo" name="<%= f.object_name %>[visibility]" value="<%= AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>" <% if curation_concern.open_access_with_embargo_release_date? %> checked="true"<% end %>/>
+        <span class="label label-warning">Open Access with Embargo</span> Treated as <span class="label label-important">Private</span> until <%= f.text_field :embargo_release_date, placeholder: Date.today,class: 'datepicker' %> then it is <span class="label label-success">Open Access</span>.
+      </label>
+      <label class="radio">
         <input type="radio" id="visibility_ndu" name="<%= f.object_name %>[visibility]" value="<%= AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>" <% if curation_concern.authenticated_only_access? %> checked="true"<% end %> />
         <span class="label label-info"><%=t('sufia.institution_name') %></span> Visible to all <%=t('sufia.institution_name') %> users.
       </label>
@@ -33,7 +26,6 @@
         <input type="radio" id="visibility_restricted" name="<%= f.object_name %>[visibility]" value="<%= AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE%>" <% if curation_concern.private_access? %> checked="true"<% end %>/>
         <span class="label label-important">Private</span> Only visible to you.
       </label>
-    </div><!-- /.controls -->
-
+    </div>
   </fieldset>
 </div>

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -99,7 +99,7 @@ describe 'end to end behavior', describe_options do
       login_as(user)
       visit('/concern/mock_curation_concerns/new')
       create_mock_curation_concern(
-        'Visibility' => 'Private',
+        'Visibility' => 'visibility_restricted',
         'I Agree' => true,
         'Title' => ''
       )
@@ -117,7 +117,7 @@ describe 'end to end behavior', describe_options do
       visit('/concern/mock_curation_concerns/new')
       create_mock_curation_concern(
         'Embargo Release Date' => embargo_release_date_formatted,
-        'Visibility' => 'Open Access',
+        'Visibility' => 'visibility_open',
         'Contributors' => ['Dante'],
         'I Agree' => true
       )
@@ -155,19 +155,28 @@ describe 'end to end behavior', describe_options do
   describe 'help request' do
     let(:agreed_to_terms_of_service) { true }
     let(:sign_in_count) { 2 }
-    # I want to test both JS mode and non-JS mode
-    [true, false].each do |using_javascript|
-      it "is available for users who are authenticated and agreed to ToS", js: using_javascript do
-        login_as(user)
-        visit('/')
-        click_link("Get Started")
-        click_link "Request Help"
-        within("#new_help_request") do
-          fill_in('How can we help you', with: "I'm trapped in a fortune cookie factory!")
-          click_on("Let Us Know")
-        end
-        page.assert_selector('.notice', text: HelpRequestsController::SUCCESS_NOTICE)
+    it "with JS is available for users who are authenticated and agreed to ToS", js: true do
+      login_as(user)
+      visit('/')
+      click_link("Get Started")
+      click_link "Request Help"
+      within("#new_help_request") do
+        fill_in('How can we help you', with: "I'm trapped in a fortune cookie factory!")
+        click_on("Let Us Know")
       end
+      page.assert_selector('.notice', text: HelpRequestsController::SUCCESS_NOTICE)
+    end
+
+    it "without JS is available for users who are authenticated and agreed to ToS", js: false do
+      login_as(user)
+      visit('/')
+      click_link("Get Started")
+      click_link "Request Help"
+      within("#new_help_request") do
+        fill_in('How can we help you', with: "I'm trapped in a fortune cookie factory!")
+        click_on("Let Us Know")
+      end
+      page.assert_selector('.notice', text: HelpRequestsController::SUCCESS_NOTICE)
     end
   end
 
@@ -205,7 +214,7 @@ describe 'end to end behavior', describe_options do
       classify_what_you_are_uploading('Mock Curation Concern')
       create_mock_curation_concern(
         "Title" => 'Mock Curation Concern',
-        'Visibility' => 'Open Access',
+        'Visibility' => 'visibility_open',
         "Upload your thesis" => initial_file_path,
         "Assign DOI" => true,
         "Contributors" => contributors,
@@ -216,7 +225,7 @@ describe 'end to end behavior', describe_options do
       # While the title is different, the filenames should be the same
       add_a_related_file(
         "Title" => 'Related File',
-        'Visibility' => authenticated_visibility_text,
+        'Visibility' => 'visibility_ndu',
         "Upload a related file" => initial_file_path
       )
 
@@ -231,6 +240,7 @@ describe 'end to end behavior', describe_options do
         '.generic_file.attributes .title.attribute',
         text: "Related File",count: 1
       )
+
       page.assert_selector(
         '.generic_file.attributes .permission.attribute',
         text: authenticated_visibility_text,count: 1
@@ -258,7 +268,7 @@ describe 'end to end behavior', describe_options do
       get_started
       agree_to_terms_of_service
       classify_what_you_are_uploading('Mock Curation Concern')
-      create_mock_curation_concern('I Agree' => true, 'Visibility' => 'Open Access')
+      create_mock_curation_concern('I Agree' => true, 'Visibility' => 'visibility_open')
       path_to_view_thesis = view_your_new_thesis
       path_to_edit_thesis = edit_your_thesis
       view_your_updated_thesis
@@ -295,7 +305,7 @@ describe 'end to end behavior', describe_options do
   def create_mock_curation_concern(options = {})
     options['Title'] ||= initial_title
     options['Upload your thesis'] ||= initial_file_path
-    options['Visibility'] ||= 'Private'
+    options['Visibility'] ||= 'visibility_restricted'
     options["Button to click"] ||= "Create Mock curation concern"
     options["Contributors"] ||= ["Dante"]
     options["Content License"] ||= Sufia::Engine.config.cc_licenses.keys.first
@@ -343,7 +353,7 @@ describe 'end to end behavior', describe_options do
   def add_a_related_file(options = {})
     options['Title'] ||= initial_title
     options['Upload a file'] ||= initial_file_path
-    options['Visibility'] ||= 'Private'
+    options['Visibility'] ||= 'visibility_restricted'
     within("form.new_generic_file") do
       fill_in("Title", with: options['Title'])
       attach_file("Upload a file", options['Upload a file'])

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -73,7 +73,7 @@ describe ApplicationHelper do
   end
 
   describe '#link_to_edit_permissions' do
-    let(:solr_document) { {read_access_group_t: access_policy } }
+    let(:solr_document) { {read_access_group_t: access_policy, embargo_release_date_dt: embargo_release_date } }
     let(:user) { FactoryGirl.create(:user) }
     let(:curation_concern) {
       FactoryGirl.create_curation_concern(
@@ -82,6 +82,7 @@ describe ApplicationHelper do
     }
     let(:visibility) { nil }
     let(:access_policy) { nil }
+    let(:embargo_release_date) { nil }
     describe 'with a "registered" access group' do
       let(:expected_label) { t('sufia.institution_name') }
       let(:visibility) { AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED } # Can we change this?
@@ -96,18 +97,35 @@ describe ApplicationHelper do
       end
     end
     describe 'with a "public" access group' do
-      let(:expected_label) { "Open Access" }
       let(:access_policy) { 'public' }
-      let(:visibility) { AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC}
-      it 'renders an "Open Access" label' do
-        rendered = helper.link_to_edit_permissions(curation_concern, solr_document)
-        expect(rendered).to(
-          have_tag("a#permission_#{curation_concern.to_param}") {
-            with_tag("span.label.label-success", with: {title: expected_label }, text: expected_label)
-          }
-        )
+      describe 'without embargo release date' do
+        let(:expected_label) { "Open Access" }
+        let(:visibility) { AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC}
+        it 'renders an "Open Access" label' do
+          rendered = helper.link_to_edit_permissions(curation_concern, solr_document)
+          expect(rendered).to(
+            have_tag("a#permission_#{curation_concern.to_param}") {
+              with_tag("span.label.label-success", with: {title: expected_label }, text: expected_label)
+            }
+          )
+        end
+      end
+
+      describe 'with an embargo release date' do
+        let(:expected_label) { "Open Access with Embargo" }
+        let(:embargo_release_date) { Date.today.to_s }
+        let(:visibility) { AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC}
+        it 'renders an "Open Access with Embargo" label' do
+          rendered = helper.link_to_edit_permissions(curation_concern, solr_document)
+          expect(rendered).to(
+            have_tag("a#permission_#{curation_concern.to_param}") {
+              with_tag("span.label.label-info", with: {title: expected_label }, text: expected_label)
+            }
+          )
+        end
       end
     end
+
     describe 'with a mixed "public registered" access group' do
       # This test is purely speculative to the appropriate labeling behavior and
       # does not account for whether the document is truly accessable; I suppose

--- a/spec/models/access_right_spec.rb
+++ b/spec/models/access_right_spec.rb
@@ -2,30 +2,38 @@ require 'spec_helper'
 
 describe AccessRight do
   [
-    [false, AccessRight::PERMISSION_TEXT_VALUE_PUBLIC, nil, true, false, false],
-    [false, AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED, nil, true, false, false],
-    [false, nil, nil, true, false, false],
-    [false, nil, AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, true, false, false],
-    [false, nil, AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, false, true, false],
-    [false, nil, AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, false, false, true],
-    [true, AccessRight::PERMISSION_TEXT_VALUE_PUBLIC, nil, true, false, false],
-    [true, AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED, nil, false, true, false],
-    [true, nil, nil, false, false, true],
-    [true, nil, AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, true, false, false],
-    [true, nil, AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, false, true, false],
-    [true, nil, AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, false, false, true],
-  ].each do |given_persisted, givin_permission, given_visibility, expected_open_access, expected_authentication_only, expected_private|
+    [false, AccessRight::PERMISSION_TEXT_VALUE_PUBLIC,        nil,                                              nil,             true, false, false, false],
+    [false, AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED, nil,                                              nil,             true, false, false, false],
+    [false, nil,                                              nil,                                              nil,             true, false, false, false],
+    [false, nil,                                              nil,                                              2.days.from_now, false, false, false, true],
+    [false, nil,                                              nil,                                              2.days.ago,      false, false, false, true],
+    [false, nil,                                              AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,        nil,             true, false, false, false],
+    [false, nil,                                              AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, nil,             false, true, false, false],
+    [false, nil,                                              AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE,       nil,             false, false, true, false],
+    [false, nil,                                              AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO,       nil,             false, false, false, true],
+    [true,  AccessRight::PERMISSION_TEXT_VALUE_PUBLIC,        nil,                                              nil,             true, false, false, false],
+    [true,  AccessRight::PERMISSION_TEXT_VALUE_PUBLIC,        nil,                                              2.days.from_now, false, false, false, true],
+    [true,  AccessRight::PERMISSION_TEXT_VALUE_PUBLIC,        nil,                                              2.days.ago,      false, false, false, true],
+    [true,  AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED, nil,                                              nil,             false, true, false, false],
+    [true,  nil,                                              nil,                                              nil,             false, false, true, false],
+    [true,  nil,                                              AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,        nil,             true, false, false, false],
+    [true,  nil,                                              AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, nil,             false, true, false, false],
+    [true,  nil,                                              AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE,       nil,             false, false, true, false],
+    [true,  nil,                                              AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO,       nil,             false, false, false, true],
+  ].each do |given_persisted, givin_permission, given_visibility, given_embargo_release_date, expected_open_access, expected_authentication_only, expected_private, expected_open_access_with_embargo_release_date|
     spec_text = <<-TEXT
 
     GIVEN: {
       persisted: #{given_persisted.inspect},
       permission: #{givin_permission.inspect},
-      visibility: #{given_visibility.inspect}
+      visibility: #{given_visibility.inspect},
+      embargo_release_date: #{given_embargo_release_date}
     },
     EXPECTED: {
       open_access: #{expected_open_access.inspect},
       restricted: #{expected_authentication_only.inspect},
-      private: #{expected_private.inspect}
+      private: #{expected_private.inspect},
+      open_access_with_embargo_release_date: #{expected_open_access_with_embargo_release_date}
     },
     TEXT
 
@@ -35,13 +43,15 @@ describe AccessRight do
         'permissionable',
         permissions: permissions,
         visibility: given_visibility,
-        persisted?: given_persisted
+        persisted?: given_persisted,
+        embargo_release_date: given_embargo_release_date
       )
       access_right = AccessRight.new(permissionable)
 
       expect(access_right.open_access?).to eq(expected_open_access)
       expect(access_right.authenticated_only?).to eq(expected_authentication_only)
       expect(access_right.private?).to eq(expected_private)
+      expect(access_right.open_access_with_embargo_release_date?).to eq(expected_open_access_with_embargo_release_date)
     end
   end
 end


### PR DESCRIPTION
Embargo release date is only applied to open access objects. The
previous UI was confusing in that it suggested that Permission and
Embargo are two orthogonal concerns, when in fact they were
interconnected.

IDR-60 #closes
