### PR TITLE
Updating set_visibility for embargoable items

### DIFF
--- a/app/repository_models/curation_concern/embargoable.rb
+++ b/app/repository_models/curation_concern/embargoable.rb
@@ -1,12 +1,23 @@
 require File.expand_path('../../../validators/future_date_validator', __FILE__)
 module CurationConcern
   module Embargoable
+    module VisibilityOverride
+      def set_visibility(value)
+        if value == AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
+          super(AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+        else
+          super(value)
+        end
+      end
+    end
+    include VisibilityOverride
     extend ActiveSupport::Concern
 
     included do
       validates :embargo_release_date, future_date: true
       before_save :write_embargo_release_date, prepend: true
     end
+
 
     def write_embargo_release_date
       if defined?(@embargo_release_date)

--- a/spec/support/shared/shared_examples_with_access_rights.rb
+++ b/spec/support/shared/shared_examples_with_access_rights.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 shared_examples 'with_access_rights' do
 
+  def prepare_subject_for_access_rights_visibility_test!
+    # I am doing this because the actual persistence of the objects requires
+    # so much more and I don't know for certain if it has happened.
+    subject.stub(:persisted?).and_return(true)
+  end
+
   it "has an under_embargo?" do
     expect {
       subject.under_embargo?
@@ -12,22 +18,64 @@ shared_examples 'with_access_rights' do
     expect(subject).to respond_to(:visibility=)
   end
 
-  it "has an open_access?" do
-    expect {
-      subject.open_access?
-    }.to_not raise_error(NoMethodError)
+  describe 'open access' do
+    it "has an open_access?" do
+      expect {
+        subject.open_access?
+      }.to_not raise_error(NoMethodError)
+    end
+
+    it 'sets visibility' do
+      prepare_subject_for_access_rights_visibility_test!
+      subject.set_visibility(AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+      expect(subject).to be_open_access
+    end
   end
 
-  it "has an authenticated_only_access?" do
-    expect {
-      subject.authenticated_only_access?
-    }.to_not raise_error(NoMethodError)
+  describe 'authenticated access' do
+    it 'sets visibility' do
+      prepare_subject_for_access_rights_visibility_test!
+      subject.set_visibility(AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
+      expect(subject).to be_authenticated_only_access
+    end
+
+    it "has an authenticated_only_access?" do
+      expect {
+        subject.authenticated_only_access?
+      }.to_not raise_error(NoMethodError)
+    end
   end
 
-  it "has an private_access?" do
-    expect {
-      subject.private_access?
-    }.to_not raise_error(NoMethodError)
+  describe 'private access' do
+    it 'sets visibility' do
+      prepare_subject_for_access_rights_visibility_test!
+      subject.set_visibility(AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE)
+      expect(subject).to be_private_access
+    end
+
+
+    it "has an private_access?" do
+      expect {
+        subject.private_access?
+      }.to_not raise_error(NoMethodError)
+    end
+  end
+
+  describe 'open_access_with_embargo_release_date' do
+    it 'sets visibility' do
+      if subject.respond_to?(:embargo_release_date=)
+        prepare_subject_for_access_rights_visibility_test!
+        subject.embargo_release_date = 2.days.from_now
+        subject.set_visibility(AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO)
+        expect(subject).to be_open_access_with_embargo_release_date
+      end
+    end
+
+    it "has an open_access_with_embargo_release_date?" do
+      expect {
+        subject.open_access_with_embargo_release_date?
+      }.to_not raise_error(NoMethodError)
+    end
   end
 
 end


### PR DESCRIPTION
Prior to this commit, if I would set the "Open Access with Embargo
Date", it would be treated as private; This is because the Sufia default
method #set_visibility is only aware of three values. I am intercepting
that value.

@WIP - I believe there is a logical inconsistency in the data validation
and open access.
