### PR TITLE
Removing .load_and_authorize_resource

### DIFF
--- a/app/controllers/curation_concern/base_controller.rb
+++ b/app/controllers/curation_concern/base_controller.rb
@@ -21,7 +21,14 @@ module CurationConcern
     before_filter :agreed_to_terms_of_service!
     prepend_before_filter :normalize_identifier, except: [:index, :new, :create]
     before_filter :curation_concern, except: [:index]
-    load_and_authorize_resource :curation_concern, except: [:index, :new, :create], class: "ActiveFedora::Base"
+
+    class_attribute :excluded_actions_for_curation_concern_authorization
+    self.excluded_actions_for_curation_concern_authorization = [:new, :create]
+    before_filter :authorize_curation_concern!, except: excluded_actions_for_curation_concern_authorization
+    def authorize_curation_concern!
+      authorize!(action_name.to_sym, curation_concern) || true
+    end
+
 
     attr_reader :curation_concern
     helper_method :curation_concern

--- a/app/controllers/curation_concern/generic_files_controller.rb
+++ b/app/controllers/curation_concern/generic_files_controller.rb
@@ -28,8 +28,7 @@ class CurationConcern::GenericFilesController < CurationConcern::BaseController
   end
   protected :authorize_edit_parent_rights!
 
-  before_filter :curation_concern
-  load_and_authorize_resource :curation_concern, class: "ActiveFedora::Base", except: [:new, :create]
+  self.excluded_actions_for_curation_concern_authorization = [:new, :create]
 
   def curation_concern
     @curation_concern ||=

--- a/spec/support/feature_support.rb
+++ b/spec/support/feature_support.rb
@@ -3,4 +3,7 @@ module FeatureSupport
     user.reload # because the user isn't re-queried via Warden
     super(user, scope: :user, run_callbacks: false)
   end
+  def logout(user=:user)
+    super(user)
+  end
 end


### PR DESCRIPTION
The CanCan.load_and_authorize_resource was misbehaving in integration
tests. I suspect this could've become a problem in production as well.
So I have since replaced the .load_and_authorize_resource with the
configurable:
  Controller.excluded_actions_for_curation_concern_authorization
