### PR TITLE
Correcting CSS to show full popover

### DIFF
--- a/app/assets/stylesheets/modules/forms.css.scss
+++ b/app/assets/stylesheets/modules/forms.css.scss
@@ -50,6 +50,10 @@ legend small {
   }
 }
 
+.accordion-body.in {
+  overflow:visible;
+}
+
 .control-group input.inline {
   display: inline-block;
 }


### PR DESCRIPTION
In the case of popovers close to the edge of an accordion, the popover
was being truncated. This commit fixes that.
