### PR TITLE
Display DOI instead of full link.

### DIFF
--- a/app/views/curation_concern/_doi.html.erb
+++ b/app/views/curation_concern/_doi.html.erb
@@ -7,9 +7,8 @@
       <%= classify_for_display(curation_concern) %>
       has a <abbr title="Digital Object Identifier">DOI</abbr>.
     </p>
-    <p class="doi centered">
-      <%# TODO: Include a link to the _actual_ DOI. %>
-      <a href="<%= curation_concern.doi_url %>"><%= curation_concern.doi_url %></a>
+    <p>
+      <strong><%= link_to curation_concern.identifier, curation_concern.doi_url %></strong>
     </p>
     <p>
       This <abbr title="Digital Object Identifier">DOI</abbr> link is the best way for others to cite your work.


### PR DESCRIPTION
This will display only the DOI part instead of the full link.
