### PR TITLE
Updating multi-value builder required attribute

### DIFF
--- a/app/inputs/multi_value_input.rb
+++ b/app/inputs/multi_value_input.rb
@@ -39,11 +39,12 @@ class MultiValueInput < SimpleForm::Inputs::CollectionInput
     options[:value] = value
     if @rendered_first_element
       options[:id] = nil
+      options[:required] = nil
     else
       options[:id] ||= input_dom_id
     end
-    options[:class] ||= ''
-    options[:class] << " #{input_dom_id} multi-text-field"
+    options[:class] ||= []
+    options[:class] += [" #{input_dom_id} multi-text-field"]
     options[:'aria-labelledby'] = label_id
     @rendered_first_element = true
     @builder.text_field(attribute_name, options)

--- a/spec/inputs/multi_value_input_spec.rb
+++ b/spec/inputs/multi_value_input_spec.rb
@@ -16,7 +16,8 @@ describe 'MultiValueInput' do
     foo.bar = bar
     input_for(foo, :bar,
               {
-                as: :multi_value
+                as: :multi_value,
+                required: true
               }
               )
   }
@@ -25,18 +26,20 @@ describe 'MultiValueInput' do
     it 'renders multi-value' do
       expect(subject).to have_tag('.control-group.foo_bar.multi_value') do
         with_tag('.control-label') do
-          with_tag('label.multi_value', text: 'Bar', for: 'foo_bar')
+          with_tag('label.multi_value.required', text: '* Bar', with: {for: 'foo_bar'}) do
+            with_tag("abbr")
+          end
         end
         with_tag('.controls') do
           with_tag('ul.listing') do
             with_tag('li.field-wrapper') do
-              with_tag('input.foo_bar.multi-text-field#foo_bar', name: 'foo[bar][]', value: 'bar1', multiple: 'multiple')
+              with_tag('input.foo_bar.required.multi-text-field#foo_bar', with: {name: 'foo[bar][]', value: 'bar1', required: 'required'})
             end
             with_tag('li.field-wrapper') do
-              with_tag('input.foo_bar.multi-text-field', name: 'foo[bar][]', value: 'bar2', multiple: 'multiple')
+              with_tag('input.foo_bar.multi-text-field', with: {name: 'foo[bar][]', value: 'bar2'}, without: {required: 'required'})
             end
             with_tag('li.field-wrapper') do
-              with_tag('input.foo_bar.multi-text-field', name: 'foo[bar][]', value: '', multiple: 'multiple')
+              with_tag('input.foo_bar.multi-text-field', with: {name: 'foo[bar][]', value: ''}, without: {required: 'required'})
             end
           end
         end


### PR DESCRIPTION
Prior to this commit, if an attribute was required, all inputs of a
multi-value type input were required. This commit enforces the
requirement only on the first element.

IDR-191 #resolve
