### PR TITLE
Remove border-based accordion indicators from facets

### DIFF
--- a/app/assets/stylesheets/modules/accordion.css.scss
+++ b/app/assets/stylesheets/modules/accordion.css.scss
@@ -1,29 +1,31 @@
-.accordion .accordion-toggle {
-  color:$blue
+.accordion {
+  .accordion-toggle {
+    color:$blue
+  }
+
+  .accordion-toggle:hover {
+    text-decoration:none;
+  }
 }
 
-.accordion .accordion-toggle:hover {
-  text-decoration:none;
-}
+.js .accordion {
+  .accordion-toggle:before {
+    content:"";
+    display:inline-block;
+    width: 0;
+    height: 0;
+    margin:0 .4em .25em -.2em;
+    border-style:solid;
+    border-color:$blue transparent transparent transparent;
+    border-width:.3em .3em 0 .3em;
+  }
 
-.js .accordion-toggle:before {
-  content:"";
-  display:inline-block;
-  width: 0;
-  height: 0;
-  margin:0 .4em .25em -.2em;
-  border-style:solid;
-  border-color:$blue transparent transparent transparent;
-  border-width:.3em .3em 0 .3em;
+  .accordion-toggle.collapsed:before {
+    margin:0 .5em .2em 0;
+    border-color:transparent transparent transparent $blue;
+    border-width:.3em 0 .3em .3em;
+  }
 }
-
-.js .accordion-toggle.collapsed:before {
-  margin-right:.5em;
-  margin:0 .5em .2em 0;
-  border-color:transparent transparent transparent $blue;
-  border-width:.3em 0 .3em .3em;
-}
-
 
 /* If form elements are present in an accordion they won't be wrapped in a row */
 .accordion-inner .control-group {


### PR DESCRIPTION
I'd like to replace this with an implementation that actually works.
That's off the table for today.
