### PR TITLE
Updating embargo release date for non-embargo

### DIFF
--- a/app/repository_models/curation_concern/embargoable.rb
+++ b/app/repository_models/curation_concern/embargoable.rb
@@ -6,6 +6,7 @@ module CurationConcern
         if value == AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
           super(AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
         else
+          self.embargo_release_date = nil
           super(value)
         end
       end
@@ -21,7 +22,7 @@ module CurationConcern
 
     def write_embargo_release_date
       if defined?(@embargo_release_date)
-        embargoable_persistence_container.embargo_release_date = embargo_release_date
+        embargoable_persistence_container.embargo_release_date = @embargo_release_date
       end
       true
     end
@@ -29,7 +30,7 @@ module CurationConcern
 
     def embargo_release_date=(value)
       @embargo_release_date = begin
-        value.to_date
+        value.present? ? value.to_date : nil
       rescue NoMethodError
         value
       end

--- a/spec/support/shared/shared_examples_with_access_rights.rb
+++ b/spec/support/shared/shared_examples_with_access_rights.rb
@@ -71,6 +71,15 @@ shared_examples 'with_access_rights' do
       end
     end
 
+    it 'removes embargo release date when non embargo is set' do
+      if subject.respond_to?(:embargo_release_date=)
+        prepare_subject_for_access_rights_visibility_test!
+        subject.embargo_release_date = 2.days.from_now
+        subject.set_visibility(AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
+        expect(subject.embargo_release_date).to be_nil
+      end
+    end
+
     it "has an open_access_with_embargo_release_date?" do
       expect {
         subject.open_access_with_embargo_release_date?


### PR DESCRIPTION
Prior to this patch, it would be possible to specify an embargo release
date but a non-embargo access right. If this was the case, the embargo
release date would persist and could then "show up" again if the object
were transitioned from Private to Open Access. Instead of showing up
as Open Access, the object that had just transitioned would be Open
Access with Embargo Release Date.

IDR-193 #resolve
