### PR TITLE
Fixing the end to end tests

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -16,10 +16,6 @@
 # -*- encoding : utf-8 -*-
 require 'blacklight/catalog'
 
-# bl_advanced_search 1.2.4 is doing unitialized constant on these because we're calling ParseBasicQ directly
-require 'parslet'
-require 'parsing_nesting/tree'
-
 class CatalogController < ApplicationController
   include Blacklight::Catalog
   # Extend Blacklight::Catalog with Hydra behaviors (primarily editing).

--- a/app/views/dashboard/_facet_selected.html.erb
+++ b/app/views/dashboard/_facet_selected.html.erb
@@ -1,26 +1,10 @@
-<%#
-Copyright © 2012 The Pennsylvania State University
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-%>
-
 <%# there has got to be a hipster ruby way to do this better %>
 <% if params[:f] %>
   <% params[:f].each do |k,v| %>
     <% v.each do |selected_facet| %>
-      <% link_options = remove_facet_params(k, selected_facet, params).merge!Hash["controller" => "dashboard", :action=> "index"] %>
+      <% link_options = remove_facet_params(k, selected_facet, params).merge!Hash["controller" => "catalog", :action=> "index"] %>
       <div class="alert alert-warning">
-        <%= link_to 'X', sufia.url_for(link_options), {:class=>'close', :'data-dismiss' => "alert" } %>
+        <%= link_to 'X', url_for(link_options), {:class=>'close', :'data-dismiss' => "alert" } %>
         <i class="icon-ok icon-large"></i> <strong><%= selected_facet %></strong>
       </div>
     <% end %>

--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -88,6 +88,11 @@ This generator makes the following changes to your application:
     end
   end
 
+  def remove_catalog_controller
+    say_status("warning", "Removing Blacklight's generated CatalogController...It will cause you grief", :yellow)
+    remove_file('app/controllers/catalog_controller.rb')
+  end
+
   private
 
   def better_migration_template (file)

--- a/spec/skeleton/lib/generators/test_app_generator.rb
+++ b/spec/skeleton/lib/generators/test_app_generator.rb
@@ -8,6 +8,10 @@ class TestAppGenerator < Rails::Generators::Base
 
     generate 'curate', '-f'
 
+    gsub_file('config/environments/test.rb', /^.*config\.consider_all_requests_local.*$/) do |match|
+      match = "  # For end to end specs, I want the exception handler capturing things; Not raising exceptions.\n  config.consider_all_requests_local = ENV['LOCAL'] || false"
+    end
+
     initializer 'curate_initializer.rb' do
       <<-EOV
       Curate.configure do |config|


### PR DESCRIPTION
The auto-generated blacklight catalog controller in the spec/internal
app needed to go; Its solr configurations were incorrect for the
curate engine.

Also, I want the application, by default in test, to not raise an
exception but instead render the exception page. This is overridable
at the environment level.

Closes ndlib/planning#84
