### PR TITLE
Updating page result when issuing a null search

### DIFF
--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -21,35 +21,28 @@
 
 <% end %>
 
-<% if has_search_parameters? %>
-  <h3>Search Results</h3>
-  <div class="alert alert-info search-constraints">
-    <i class="icon-search icon-large"></i>
-    You searched for:
-      <%= render_constraints(params) %>
+<h3>Search Results</h3>
+<div class="alert alert-info search-constraints">
+  <i class="icon-search icon-large"></i>
+  You searched for:
+    <%= render_constraints(params) %>
+</div>
+
+<%= render :partial => 'did_you_mean' %>
+<%= render :partial => 'facet_selected' %>
+
+<div class="row">
+  <div class="span6">
+    <%= render_pagination_info @response, :entry_name=>'item' %>
+    <%= render 'sort_and_per_page' %>
   </div>
-
-  <%= render :partial => 'did_you_mean' %>
-  <%= render :partial => 'facet_selected' %>
-
-  <div class="row">
-    <div class="span6">
-      <%= render_pagination_info @response, :entry_name=>'item' %>
-      <%= render 'sort_and_per_page' %>
-    </div>
-    <div class="span3 emphatic-action-area">
-      <%= link_to "New Search", catalog_index_path, :id=>"startOverLink", :class=>"btn btn-primary pull-right" %>
-    </div>
+  <div class="span3 emphatic-action-area">
+    <%= link_to "New Search", catalog_index_path, :id=>"startOverLink", :class=>"btn btn-primary pull-right" %>
   </div>
+</div>
 
-  <%= render 'results_pagination' %>
+<%= render 'results_pagination' %>
 
-  <%= render 'document_list' %>
+<%= render 'document_list' %>
 
-  <%= render 'results_pagination' %>
-
-<% else %>
-
-  <%= render 'home' %>
-
-<% end %>
+<%= render 'results_pagination' %>

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe_options = {type: :feature}
+if ENV['JS']
+  describe_options[:js] = true
+end
+
+describe 'catalog search', describe_options do
+  it 'renders search results for null search' do
+    visit('/')
+    within('.search-form') do
+      click_button("Go")
+    end
+
+    page.should have_tag('h3', text: "Search Results")
+    page.should have_tag(".search-constraints", with_text: "You searched for:")
+  end
+end


### PR DESCRIPTION
Instead of rendering the "What is Curate" when a null search is
issued, render the search with a "You searched for: "

Closes ndlib/planning#89
