### PR TITLE
Updating generator to stub Catalog

### DIFF
--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -54,7 +54,7 @@ This generator makes the following changes to your application:
 
   def remove_catalog_controller
     say_status("warning", "Removing Blacklight's generated CatalogController...It will cause you grief", :yellow)
-    remove_file('app/controllers/catalog_controller.rb')
+    template('catalog_controller.rb', 'app/controllers/catalog_controller.rb')
   end
 
   # Setup the database migrations

--- a/lib/generators/curate/templates/catalog_controller.rb
+++ b/lib/generators/curate/templates/catalog_controller.rb
@@ -1,0 +1,6 @@
+# Generated via `rails generate curate`",
+require Curate::Engine.root.join('app/controllers/catalog_controller.rb')
+
+# If you want to re-open CatalogController uncomment the following lines:
+# class CatalogController
+# end


### PR DESCRIPTION
Instead of deleting the CatalogController, I want the generatore (i.e.
`rails g curate`) to create a app/controllers/catalog_controller.rb
that requires Curate's catalog controller. It can then be overriden
as required.

Closes ndlib/planning#88
Addresses curationexperts/curate_dce#2
