### PR TITLE
Removing Devise generated views

### DIFF
--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -33,6 +33,7 @@ This generator makes the following changes to your application:
 
   def run_required_generators
     generate "blacklight --devise"
+    remove_dir('app/views/devise')
     generate "hydra:head -f"
     generate "sufia:models:install"
   end


### PR DESCRIPTION
The Curate generator now removes the devise created views; This way
we can manage our own views for user management and signin.
