### PR TITLE
Adding ActiveFedora::RegisteredAttributes

### DIFF
--- a/app/repository_models/generic_work.rb
+++ b/app/repository_models/generic_work.rb
@@ -5,43 +5,40 @@ class GenericWork < ActiveFedora::Base
   include CurationConcern::Embargoable
   include CurationConcern::WithAccessRight
 
+  include ActiveFedora::RegisteredAttributes
+
   has_metadata "descMetadata", type: GenericWorkRdfDatastream
 
-  delegate_to(
-    :descMetadata,
-    [
-      :title,
-      :created,
-      :description,
-      :date_uploaded,
-      :date_modified,
-      :available,
-      :archived_object_type,
-      :creator,
-      :content_format,
-      :identifier,
-      :rights
-    ],
-    unique: true
-  )
-  delegate_to(
-    :descMetadata,
-    [
-      :contributor,
-      :publisher,
-      :bibliographic_citation,
-      :source,
-      :language,
-      :extent,
-      :requires,
-      :subject
-    ]
-  )
+  attribute :title, datastream: :descMetadata,
+    multiple: false,
+    validates: {presence: { message: 'Your work must have a title.' }}
 
-  validates :title, presence: { message: 'Your thesis must have a title.' }
-  validates :rights, presence: { message: 'You must select a license for your work.' }
+  attribute :rights, datastream: :descMetadata,
+    multiple: false,
+    validates: {presence: { message: 'You must select a license for your work.' }}
 
-  attr_accessor :thesis_file
-  attr_accessor :linked_resource_url
+  attribute :created, datastream: :descMetadata, multiple: false
+  attribute :description, datastream: :descMetadata, multiple: false
+  attribute :date_uploaded, datastream: :descMetadata, multiple: false
+  attribute :date_modified, datastream: :descMetadata, multiple: false
+  attribute :available, datastream: :descMetadata, multiple: false
+  attribute :archived_object_type, datastream: :descMetadata, multiple: false
+  attribute :creator, datastream: :descMetadata, multiple: false
+  attribute :content_format, datastream: :descMetadata, multiple: false
+  attribute :identifier, datastream: :descMetadata, multiple: false
+
+  attribute :contributor, datastream: :descMetadata, multiple: true
+  attribute :publisher, datastream: :descMetadata, multiple: true
+  attribute :bibliographic_citation, datastream: :descMetadata, multiple: true
+  attribute :source, datastream: :descMetadata, multiple: true
+  attribute :language, datastream: :descMetadata, multiple: true
+  attribute :extent, datastream: :descMetadata, multiple: true
+  attribute :requires, datastream: :descMetadata, multiple: true
+  attribute :subject, datastream: :descMetadata, multiple: true
+
+  attribute :thesis_file, multiple: true, form: {as: :file},
+    hint: "CTRL-Click (Windows) or CMD-Click (Mac) to select multiple files."
+
+  attribute :linked_resource_url, multiple: true
 
 end

--- a/curate.gemspec
+++ b/curate.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
   s.add_dependency "devise-guests", "~> 0.3"
   s.add_dependency 'browser'
   s.add_dependency 'breadcrumbs_on_rails'
+  s.add_dependency 'active_fedora-registered_attributes'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "factory_girl_rails"

--- a/lib/curate.rb
+++ b/lib/curate.rb
@@ -5,6 +5,7 @@ require "curate/user"
 require 'simple_form'
 require 'bootstrap-datepicker-rails'
 require 'hydra-batch-edit'
+require 'active_fedora/registered_attributes'
 
 module Curate
 end


### PR DESCRIPTION
Relying on the potentially more robust ActiveFedora::
RegisteredAttributes to codify what the attributes are for the given
model; By registering an attribute, we can introspect on the model
for:
- generating forms
- generating default views
- generating reasonably helpful API documentation/explanation
- helping developers readily see what the data attributes are
