### PR TITLE
Removing HelpRequests#force_update_user_profile!

### DIFF
--- a/app/controllers/help_requests_controller.rb
+++ b/app/controllers/help_requests_controller.rb
@@ -3,7 +3,6 @@ class HelpRequestsController < ApplicationController
   with_themed_layout
   before_filter :authenticate_user!
   before_filter :agreed_to_terms_of_service!
-  before_filter :force_update_user_profile!
 
   add_breadcrumb 'Help Request', lambda {|controller| controller.request.path }
 


### PR DESCRIPTION
If a user is logged in, regardless of their profile state, they should
be able to submit a help request.
