### PR TITLE
Issue 17: As a faculty I want to upload my dataset and describe it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vendor/cache
 .sass-cache
 tmp/*
 .sass-cache
+.idea/

--- a/app/controllers/curation_concern/datasets_controller.rb
+++ b/app/controllers/curation_concern/datasets_controller.rb
@@ -1,0 +1,13 @@
+class CurationConcern::DatasetsController < CurationConcern::GenericWorksController
+
+  register :actor do
+    CurationConcern.actor(curation_concern, current_user, params[:dataset])
+  end
+  register :curation_concern do
+    if params[:id]
+      Dataset.find(params[:id])
+    else
+      Dataset.new(params[:dataset])
+    end
+  end
+end

--- a/app/models/classify_concern.rb
+++ b/app/models/classify_concern.rb
@@ -3,7 +3,7 @@ class ClassifyConcern
   # @TODO - This should be part of the application configuration
   # or detected on load
   VALID_CURATION_CONCERN_CLASS_NAMES = [
-    'GenericWork'
+    'GenericWork', 'Dataset'
   ]
   UPCOMING_CONCERNS = []
 

--- a/app/repository_models/dataset.rb
+++ b/app/repository_models/dataset.rb
@@ -1,0 +1,43 @@
+class Dataset < ActiveFedora::Base
+  include CurationConcern::Model
+  include CurationConcern::WithGenericFiles
+  include CurationConcern::WithLinkedResources
+  include CurationConcern::Embargoable
+
+  include ActiveFedora::RegisteredAttributes
+
+  has_metadata "descMetadata", type: GenericWorkRdfDatastream
+
+  attribute :title, datastream: :descMetadata,
+            multiple: false,
+            validates: {presence: { message: 'Your dataset must have a title.' }}
+
+  attribute :rights, datastream: :descMetadata,
+            multiple: false,
+            validates: {presence: { message: 'You must select a license for your dataset.' }}
+
+  attribute :created, datastream: :descMetadata, multiple: false
+  attribute :description, datastream: :descMetadata, multiple: false
+  attribute :date_uploaded, datastream: :descMetadata, multiple: false
+  attribute :date_modified, datastream: :descMetadata, multiple: false
+  attribute :available, datastream: :descMetadata, multiple: false
+  attribute :archived_object_type, datastream: :descMetadata, multiple: false
+  attribute :creator, datastream: :descMetadata, multiple: false
+  attribute :content_format, datastream: :descMetadata, multiple: false
+  attribute :identifier, datastream: :descMetadata, multiple: false
+
+  attribute :contributor, datastream: :descMetadata, multiple: true
+  attribute :publisher, datastream: :descMetadata, multiple: true
+  attribute :bibliographic_citation, datastream: :descMetadata, multiple: true
+  attribute :source, datastream: :descMetadata, multiple: true
+  attribute :language, datastream: :descMetadata, multiple: true
+  attribute :extent, datastream: :descMetadata, multiple: true
+  attribute :requires, datastream: :descMetadata, multiple: true
+  attribute :subject, datastream: :descMetadata, multiple: true
+
+  attribute :files, multiple: true, form: {as: :file},
+            hint: "CTRL-Click (Windows) or CMD-Click (Mac) to select multiple files."
+
+  attribute :linked_resource_url, multiple: true
+
+end

--- a/app/services/curation_concern/dataset_actor.rb
+++ b/app/services/curation_concern/dataset_actor.rb
@@ -1,0 +1,4 @@
+module CurationConcern
+  class DatasetActor < GenericWorkActor
+  end
+end

--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -74,7 +74,7 @@ This generator makes the following changes to your application:
 
   # The engine routes have to come after the devise routes so that /users/sign_in will work
   def inject_routes
-    routing_code = "\n  curate_for containers: [:generic_works]\n"
+    routing_code = "\n  curate_for containers: [:generic_works, :datasets]\n"
     sentinel = /devise_for :users/
     inject_into_file 'config/routes.rb', routing_code, { :after => sentinel, :verbose => false }
     gsub_file 'config/routes.rb', /^\s+root.+$/, "  root 'welcome#index'"

--- a/spec/controllers/curation_concern/datasets_controller_spec.rb
+++ b/spec/controllers/curation_concern/datasets_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe CurationConcern::DatasetsController do
+  let(:user) { FactoryGirl.create(:user) }
+  before { sign_in user }
+
+  describe "#show" do
+    context "my own private work" do
+      let(:dataset) { FactoryGirl.create(:private_dataset, user: user) }
+      it "should show me the page" do
+        get :show, id: dataset
+        expect(response).to be_success
+      end
+    end
+    context "someone elses private work" do
+      let(:dataset) { FactoryGirl.create(:private_dataset) }
+      it "should show 401 Unauthorized" do
+        get :show, id: dataset
+        expect(response.status).to eq 401
+      end
+    end
+    context "someone elses public work" do
+      let(:dataset) { FactoryGirl.create(:public_dataset, user: user) }
+      it "should show me the page" do
+        get :show, id: dataset
+        expect(response).to be_success
+      end
+    end
+  end
+
+  describe "#create" do
+    it "should create a work" do
+      controller.curation_concern.stub(:persisted?).and_return(true)
+      controller.actor = double(:create! => true)
+      post :create, accept_contributor_agreement: "accept"
+      response.should redirect_to curation_concern_dataset_path(controller.curation_concern)
+    end
+  end
+
+  describe "#update" do
+    let(:dataset) { FactoryGirl.create(:dataset, user: user) }
+    it "should update the work " do
+      controller.actor = double(:update! => true, :visibility_changed? => false)
+      patch :update, id: dataset
+      response.should redirect_to curation_concern_dataset_path(controller.curation_concern)
+    end
+    describe "changing rights" do
+      it "should prompt to change the files access" do
+        controller.actor = double(:update! => true, :visibility_changed? => true)
+        patch :update, id: dataset
+        response.should redirect_to confirm_curation_concern_permission_path(controller.curation_concern)
+      end
+    end
+  end
+end

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -1,0 +1,32 @@
+FactoryGirl.define do
+  factory :dataset do
+    ignore do
+      user {FactoryGirl.create(:user)}
+    end
+    sequence(:title) {|n| "Title #{n}"}
+    rights { Sufia.config.cc_licenses.keys.first }
+    date_uploaded { Date.today }
+    date_modified { Date.today }
+    visibility Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+    before(:create) { |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+      work.creator = evaluator.user.to_s
+    }
+
+    factory :private_dataset do
+      visibility Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
+    factory :public_dataset do
+      visibility Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+    factory :dataset_with_files do
+      ignore do
+        file_count 3
+      end
+
+      after(:create) do |work, evaluator|
+        FactoryGirl.create_list(:generic_file, evaluator.file_count, batch: work, user: evaluator.user)
+      end
+    end
+  end
+end

--- a/spec/features/dataset_spec.rb
+++ b/spec/features/dataset_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe 'Creating a dataset' do
+  let(:user) { FactoryGirl.create(:user) }
+
+  describe 'with a related link' do
+    it "should allow me to attach the link on the create page" do
+      login_as(user)
+      visit root_path
+      click_link "Get Started"
+      click_link "Submit a work"
+      classify_what_you_are_uploading 'Dataset'
+      within '#new_dataset' do
+        fill_in "Title", with: "My title"
+        fill_in "External link", with: "http://www.youtube.com/watch?v=oHg5SJYRHA0"
+        select(Sufia.config.cc_licenses.keys.first, from: I18n.translate('sufia.field_label.rights'))
+        check("I have read and accept the contributor licence agreement")
+        click_button("Create Dataset")
+      end
+      expect(page).to have_selector('h1', text: 'Dataset')
+      within ('.linked_resource.attributes') do
+        expect(page).to have_link('http://www.youtube.com/watch?v=oHg5SJYRHA0', href: 'http://www.youtube.com/watch?v=oHg5SJYRHA0')
+      end
+    end
+  end
+end
+
+describe 'An existing dataset' do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:dataset) { FactoryGirl.create(:dataset, user: user) }
+  let(:you_tube_link) { 'http://www.youtube.com/watch?v=oHg5SJYRHA0' }
+
+  it 'should allow me to attach a linked resource' do
+    login_as(user)
+    visit curation_concern_dataset_path(dataset)
+    click_link 'Add an External Link'
+
+    within '#new_linked_resource' do
+      fill_in 'External link', with: you_tube_link
+      click_button 'Add External Link'
+    end
+
+    within ('.linked_resource.attributes') do
+      expect(page).to have_link(you_tube_link, href: you_tube_link)
+    end
+  end
+
+  it 'cancel takes me back to the dashboard' do
+    login_as(user)
+    visit curation_concern_dataset_path(dataset)
+    click_link 'Add an External Link'
+    page.should have_link('Cancel', href: dashboard_index_path)
+  end
+end
+

--- a/spec/models/classify_concern_spec.rb
+++ b/spec/models/classify_concern_spec.rb
@@ -9,12 +9,15 @@ describe ClassifyConcern do
       expect(ClassifyConcern.all_curation_concern_classes).to include(GenericWork)
       expect(ClassifyConcern.all_curation_concern_classes).to_not include('GenericWork')
     end
+    it 'has Dataset' do
+      expect(ClassifyConcern.all_curation_concern_classes).to include(Dataset)
+      expect(ClassifyConcern.all_curation_concern_classes).to_not include('Dataset')
+    end
   end
 
   describe '#all_curation_concern_classes' do
-    it 'has GenericWork' do
-      expect(subject.all_curation_concern_classes).to include(GenericWork)
-      expect(subject.all_curation_concern_classes).to_not include('GenericWork')
+    it 'relies on the list from ClassifyConcern Class' do
+      expect(subject.all_curation_concern_classes).to eql(ClassifyConcern.all_curation_concern_classes)
     end
   end
 

--- a/spec/repository_models/dataset_spec.rb
+++ b/spec/repository_models/dataset_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Dataset do
+  subject { Dataset.new }
+
+  include_examples 'with_access_rights'
+  include_examples 'is_embargoable'
+  include_examples 'has_dc_metadata'
+
+  it { should have_unique_field(:available) }
+  it { should have_unique_field(:archived_object_type) }
+
+
+end

--- a/spec/repository_models/generic_work_spec.rb
+++ b/spec/repository_models/generic_work_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe GenericWork do
+  subject { GenericWork.new }
+
+  include_examples 'with_access_rights'
+  include_examples 'is_embargoable'
+  include_examples 'has_dc_metadata'
+
+  it { should have_unique_field(:available) }
+  it { should have_unique_field(:archived_object_type) }
+
+end

--- a/spec/services/curation_concern/dataset_actor_spec.rb
+++ b/spec/services/curation_concern/dataset_actor_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+describe CurationConcern::DatasetActor do
+  include ActionDispatch::TestProcess
+  let(:user) { FactoryGirl.create(:user) }
+  let(:file) { fixture_file_upload('/files/image.png', 'image/png') }
+
+  subject {
+    CurationConcern.actor(curation_concern, user, attributes)
+  }
+
+  describe '#create' do
+
+    let(:curation_concern) { Dataset.new(pid: CurationConcern.mint_a_pid )}
+
+    describe 'valid attributes' do
+      let(:visibility) { Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+
+      describe 'with a file' do
+        let(:attributes) {
+          FactoryGirl.attributes_for(:dataset, visibility: visibility).tap {|a|
+            a[:files] = file
+          }
+        }
+        before(:each) do
+          subject.create!
+        end
+
+        describe 'authenticated visibility' do
+          it 'should stamp each file with the access rights' do
+            expect(curation_concern).to be_persisted
+            curation_concern.date_uploaded.should == Date.today
+            curation_concern.date_modified.should == Date.today
+            curation_concern.depositor.should == user.user_key
+
+            curation_concern.generic_files.count.should == 1
+            # Sanity test to make sure the file we uploaded is stored and has same permission as parent.
+            generic_file = curation_concern.generic_files.first
+            expect(generic_file.content.content).to eq file.read
+            expect(generic_file.filename).to eq 'image.png'
+
+            expect(curation_concern).to be_authenticated_only_access
+            expect(generic_file).to be_authenticated_only_access
+          end
+        end
+      end
+
+      describe 'with a linked resource' do
+        let(:attributes) {
+          FactoryGirl.attributes_for(:dataset, visibility: visibility, linked_resource_url: 'http://www.youtube.com/watch?v=oHg5SJYRHA0')
+        }
+        before(:each) do
+          subject.create!
+        end
+
+        describe 'authenticated visibility' do
+          it 'should stamp each link with the access rights' do
+            expect(curation_concern).to be_persisted
+            curation_concern.date_uploaded.should == Date.today
+            curation_concern.date_modified.should == Date.today
+            curation_concern.depositor.should == user.user_key
+
+            curation_concern.generic_files.count.should == 0
+            curation_concern.linked_resources.count.should == 1
+            # Sanity test to make sure the file we uploaded is stored and has same permission as parent.
+            link = curation_concern.linked_resources.first
+            expect(link.url).to eq 'http://www.youtube.com/watch?v=oHg5SJYRHA0'
+            expect(curation_concern).to be_authenticated_only_access
+          end
+        end
+      end
+    end
+
+    describe '#update' do
+      let(:curation_concern) { FactoryGirl.create(:generic_work, user: user)}
+      describe 'adding to collections' do
+        let!(:collection1) { FactoryGirl.create(:collection, user: user) }
+        let!(:collection2) { FactoryGirl.create(:collection, user: user) }
+        let(:attributes) {
+          FactoryGirl.attributes_for(:generic_work,
+                                     visibility: Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
+                                     collection_ids: [collection2.pid])
+        }
+        before do
+          curation_concern.apply_depositor_metadata(user.user_key)
+          curation_concern.save!
+          collection1.members << curation_concern
+          collection1.save
+        end
+        it "should add to collections" do
+          expect(curation_concern.collections).to eq [collection1]
+          subject.update!
+          expect(curation_concern.identifier).to be_blank
+          expect(curation_concern).to be_persisted
+          expect(curation_concern).to be_open_access
+          expect(curation_concern.collections).to eq [collection2]
+          expect(subject.visibility_changed?).to be_true
+        end
+      end
+    end
+  end
+end

--- a/spec/support/matchers/metadata_field_matchers.rb
+++ b/spec/support/matchers/metadata_field_matchers.rb
@@ -1,0 +1,27 @@
+# RSpec matcher to spec delegations.
+
+RSpec::Matchers.define :have_unique_field do |expected_field_name|
+  match do |subject|
+    subject.should respond_to(expected_field_name)
+    subject.send(expected_field_name).should be_nil
+  end
+
+  description do
+    "expected to have a single-valued field named #{expected_field_name}"
+  end
+
+  failure_message_for_should do |subject|
+    "#{subject.inspect} should respond to #{expected_field_name} as a single-value, not an Array. Responded with #{subject.send(expected_field_name)}"
+  end
+end
+
+RSpec::Matchers.define :have_multivalue_field do |expected_field_name|
+  match do |subject|
+    subject.should respond_to(expected_field_name)
+    subject.send(expected_field_name).should be_instance_of Array
+  end
+
+  description do
+    "expected to have a multi-valued field named #{expected_field_name}"
+  end
+end

--- a/spec/support/shared/shared_examples_has_dc_metadata.rb
+++ b/spec/support/shared/shared_examples_has_dc_metadata.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+shared_examples 'has_dc_metadata' do
+
+  # Single-valued fields
+  it { should have_unique_field(:created) }
+  it { should have_unique_field(:description) }
+  it { should have_unique_field(:date_uploaded) }
+  it { should have_unique_field(:date_modified) }
+  it { should have_unique_field(:creator) }
+  it { should have_unique_field(:content_format) }
+  it { should have_unique_field(:identifier) }
+
+  # Multivalued fields
+  it { should have_multivalue_field(:contributor) }
+  it { should have_multivalue_field(:publisher) }
+  it { should have_multivalue_field(:bibliographic_citation) }
+  it { should have_multivalue_field(:source) }
+  it { should have_multivalue_field(:language) }
+  it { should have_multivalue_field(:extent) }
+  it { should have_multivalue_field(:requires) }
+  it { should have_multivalue_field(:subject) }
+
+end


### PR DESCRIPTION
Adds test coverage for GenericWork
Adds rspec matchers for single-value and multivalue fields
Adds example set for has_dc_metadata (used when testing GenericWork & Dataset)

Adds Dataset model as a type of Work & CurationConcerns::DatasetsController as subclass of CurationConcerns::GenericWorksController 
Adds DatasetActor & wires Datasets into CurationConcerns as appropriate
Adds Feature test to ensure full flow of creating & editing Datasets works

Story Ticket: https://github.com/ndlib/planning/issues/17

Note: I didn't do anything with the sample dataset file that @rickjohnson provided (34MB).  It wasn't clear what I would need to do with it in the test suite that would warrant adding a 34MB file to the git repository.
