### PR TITLE
Replacing :actor, :curation_concern with config

### DIFF
--- a/app/controllers/curation_concern/datasets_controller.rb
+++ b/app/controllers/curation_concern/datasets_controller.rb
@@ -1,13 +1,3 @@
 class CurationConcern::DatasetsController < CurationConcern::GenericWorksController
-
-  register :actor do
-    CurationConcern.actor(curation_concern, current_user, params[:dataset])
-  end
-  register :curation_concern do
-    if params[:id]
-      Dataset.find(params[:id])
-    else
-      Dataset.new(params[:dataset])
-    end
-  end
+  self.curation_concern_type = Dataset
 end

--- a/app/controllers/curation_concern/generic_works_controller.rb
+++ b/app/controllers/curation_concern/generic_works_controller.rb
@@ -67,16 +67,22 @@ class CurationConcern::GenericWorksController < CurationConcern::BaseController
     }
   end
 
+  class_attribute :curation_concern_type
+  self.curation_concern_type = GenericWork
+
   include Morphine
   register :actor do
-    CurationConcern.actor(curation_concern, current_user, params[:generic_work])
+    CurationConcern.actor(curation_concern, current_user, params[hash_key_for_curation_concern])
   end
   register :curation_concern do
     if params[:id]
-      GenericWork.find(params[:id])
+      curation_concern_type.find(params[:id])
     else
-      GenericWork.new(params[:generic_work])
+      curation_concern_type.new(params[hash_key_for_curation_concern])
     end
   end
 
+  def hash_key_for_curation_concern
+    curation_concern_type.name.underscore.to_sym
+  end
 end

--- a/app/controllers/curation_concern/permissions_controller.rb
+++ b/app/controllers/curation_concern/permissions_controller.rb
@@ -13,7 +13,6 @@ class CurationConcern::PermissionsController < CurationConcern::BaseController
     @curation_concern ||=
     if params[:id]
       ActiveFedora::Base.find(params[:id], cast: true)
-      #ActiveFedora::Base.load_instance_from_solr(params[:id])
     else
       raise "Missing required parameter `id'"
     end

--- a/spec/controllers/curation_concern/datasets_controller_spec.rb
+++ b/spec/controllers/curation_concern/datasets_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe CurationConcern::DatasetsController do
+  include_examples 'is_a_curation_concern_controller', Dataset
   let(:user) { FactoryGirl.create(:user) }
   before { sign_in user }
 

--- a/spec/controllers/curation_concern/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concern/generic_works_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe CurationConcern::GenericWorksController do
+  include_examples 'is_a_curation_concern_controller', GenericWork
+
   let(:user) { FactoryGirl.create(:user) }
   before { sign_in user }
 

--- a/spec/support/shared/shared_examples_is_a_curation_concern_controller.rb
+++ b/spec/support/shared/shared_examples_is_a_curation_concern_controller.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+shared_examples 'is_a_curation_concern_controller' do |collection_class|
+  its(:curation_concern_type) { should eq collection_class }
+end


### PR DESCRIPTION
Instead of requiring the more archaic `register :actor` and `register
:curation_concern` replace with a class attribute that defines the
`curation_concern_type` and derives the parameter hash key from the
`curation_concern_type`.

Provide a shared example in which we can begin extracting default
behavior of a controller.
