### PR TITLE
Extracting duplicate spec code to shared example

### DIFF
--- a/spec/controllers/curation_concern/datasets_controller_spec.rb
+++ b/spec/controllers/curation_concern/datasets_controller_spec.rb
@@ -1,56 +1,5 @@
 require 'spec_helper'
 
 describe CurationConcern::DatasetsController do
-  include_examples 'is_a_curation_concern_controller', Dataset
-  let(:user) { FactoryGirl.create(:user) }
-  before { sign_in user }
-
-  describe "#show" do
-    context "my own private work" do
-      let(:dataset) { FactoryGirl.create(:private_dataset, user: user) }
-      it "should show me the page" do
-        get :show, id: dataset
-        expect(response).to be_success
-      end
-    end
-    context "someone elses private work" do
-      let(:dataset) { FactoryGirl.create(:private_dataset) }
-      it "should show 401 Unauthorized" do
-        get :show, id: dataset
-        expect(response.status).to eq 401
-      end
-    end
-    context "someone elses public work" do
-      let(:dataset) { FactoryGirl.create(:public_dataset, user: user) }
-      it "should show me the page" do
-        get :show, id: dataset
-        expect(response).to be_success
-      end
-    end
-  end
-
-  describe "#create" do
-    it "should create a work" do
-      controller.curation_concern.stub(:persisted?).and_return(true)
-      controller.actor = double(:create! => true)
-      post :create, accept_contributor_agreement: "accept"
-      response.should redirect_to curation_concern_dataset_path(controller.curation_concern)
-    end
-  end
-
-  describe "#update" do
-    let(:dataset) { FactoryGirl.create(:dataset, user: user) }
-    it "should update the work " do
-      controller.actor = double(:update! => true, :visibility_changed? => false)
-      patch :update, id: dataset
-      response.should redirect_to curation_concern_dataset_path(controller.curation_concern)
-    end
-    describe "changing rights" do
-      it "should prompt to change the files access" do
-        controller.actor = double(:update! => true, :visibility_changed? => true)
-        patch :update, id: dataset
-        response.should redirect_to confirm_curation_concern_permission_path(controller.curation_concern)
-      end
-    end
-  end
+  include_examples 'is_a_curation_concern_controller', Dataset, :all
 end

--- a/spec/controllers/curation_concern/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concern/generic_works_controller_spec.rb
@@ -1,57 +1,5 @@
 require 'spec_helper'
 
 describe CurationConcern::GenericWorksController do
-  include_examples 'is_a_curation_concern_controller', GenericWork
-
-  let(:user) { FactoryGirl.create(:user) }
-  before { sign_in user }
-
-  describe "#show" do
-    context "my own private work" do
-      let(:generic_work) { FactoryGirl.create(:private_work, user: user) }
-      it "should show me the page" do
-        get :show, id: generic_work
-        expect(response).to be_success
-      end
-    end
-    context "someone elses private work" do
-      let(:generic_work) { FactoryGirl.create(:private_work) }
-      it "should show 401 Unauthorized" do
-        get :show, id: generic_work
-        expect(response.status).to eq 401
-      end
-    end
-    context "someone elses public work" do
-      let(:generic_work) { FactoryGirl.create(:public_work) }
-      it "should show me the page" do
-        get :show, id: generic_work
-        expect(response).to be_success
-      end
-    end
-  end
-      
-  describe "#create" do
-    it "should create a work" do
-      controller.curation_concern.stub(:persisted?).and_return(true)
-      controller.actor = double(:create! => true)
-      post :create, accept_contributor_agreement: "accept"
-      response.should redirect_to curation_concern_generic_work_path(controller.curation_concern)
-    end
-  end
-
-  describe "#update" do
-    let(:generic_work) { FactoryGirl.create(:generic_work, user: user) }
-    it "should update the work " do
-      controller.actor = double(:update! => true, :visibility_changed? => false)
-      patch :update, id: generic_work
-      response.should redirect_to curation_concern_generic_work_path(controller.curation_concern)
-    end
-    describe "changing rights" do
-      it "should prompt to change the files access" do
-        controller.actor = double(:update! => true, :visibility_changed? => true)
-        patch :update, id: generic_work
-        response.should redirect_to confirm_curation_concern_permission_path(controller.curation_concern)
-      end
-    end
-  end
+  include_examples 'is_a_curation_concern_controller', GenericWork, :all
 end

--- a/spec/factories/generic_work.rb
+++ b/spec/factories/generic_work.rb
@@ -13,13 +13,13 @@ FactoryGirl.define do
       work.creator = evaluator.user.to_s
     }
 
-    factory :private_work do
+    factory :private_generic_work do
       visibility Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
     end
-    factory :public_work do
+    factory :public_generic_work do
       visibility Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
-    factory :work_with_files do
+    factory :generic_work_with_files do
       ignore do
         file_count 3
       end

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -20,10 +20,10 @@ end
 describe "Search for a work" do
   context "when not logged in" do
     before { GenericWork.delete_all }
-    let!(:public_work) { FactoryGirl.create(:public_work, 
+    let!(:public_work) { FactoryGirl.create(:public_generic_work, 
       title: "McSweeney's Schlitz wolf, gentrify skateboard occupy Godard Cosby " +
       "sweater Carles cornhole swag next level.")}
-    let!(:private_work) { FactoryGirl.create(:private_work, 
+    let!(:private_work) { FactoryGirl.create(:private_generic_work, 
       title: "McSweeney's Schlitz wolf, gentrify skateboard occupy Godard Cosby " +
       "sweater Carles cornhole swag next level.")}
     it "should find results" do

--- a/spec/features/edit_file_spec.rb
+++ b/spec/features/edit_file_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe "Editing an attached file" do
   let(:user) { FactoryGirl.create(:user) }
-  let(:work) { FactoryGirl.create(:work_with_files, file_count: 1, user: user) }
+  let(:work) { FactoryGirl.create(:generic_work_with_files, file_count: 1, user: user) }
 
   after do
     work.destroy

--- a/spec/support/shared/shared_examples_is_a_curation_concern_controller.rb
+++ b/spec/support/shared/shared_examples_is_a_curation_concern_controller.rb
@@ -1,4 +1,78 @@
 require 'spec_helper'
-shared_examples 'is_a_curation_concern_controller' do |collection_class|
+shared_examples 'is_a_curation_concern_controller' do |collection_class, actions = :all|
+  def self.optionally_include_specs(actions, action_name)
+    normalized_actions = Array(actions).flatten.compact
+    return true if normalized_actions.include?(:all)
+    return true if normalized_actions.include?(action_name.to_sym)
+    return true if normalized_actions.include?(action_name.to_s)
+  end
   its(:curation_concern_type) { should eq collection_class }
+
+  let(:user) { FactoryGirl.create(:user) }
+  before { sign_in user }
+
+  let(:curation_concern_type_underscore) { collection_class.name.underscore }
+  let(:default_work_factory_name) { curation_concern_type_underscore }
+  let(:private_work_factory_name) { "private_#{curation_concern_type_underscore}".to_sym }
+  let(:public_work_factory_name) { "public_#{curation_concern_type_underscore}".to_sym }
+
+  def path_to_curation_concern
+    public_send("curation_concern_#{curation_concern_type_underscore}_path", controller.curation_concern)
+  end
+
+  if optionally_include_specs(actions, :show)
+    describe "#show" do
+      context "my own private work" do
+        let(:a_work) { FactoryGirl.create(private_work_factory_name, user: user) }
+        it "should show me the page" do
+          get :show, id: a_work
+          expect(response).to be_success
+        end
+      end
+      context "someone elses private work" do
+        let(:a_work) { FactoryGirl.create(private_work_factory_name) }
+        it "should show 401 Unauthorized" do
+          get :show, id: a_work
+          expect(response.status).to eq 401
+        end
+      end
+      context "someone elses public work" do
+        let(:a_work) { FactoryGirl.create(public_work_factory_name) }
+        it "should show me the page" do
+          get :show, id: a_work
+          expect(response).to be_success
+        end
+      end
+    end
+
+    if optionally_include_specs(actions, :create)
+      describe "#create" do
+        it "should create a work" do
+          controller.curation_concern.stub(:persisted?).and_return(true)
+          controller.actor = double(:create! => true)
+          post :create, accept_contributor_agreement: "accept"
+          response.should redirect_to path_to_curation_concern
+        end
+      end
+    end
+
+    if optionally_include_specs(actions, :update)
+      describe "#update" do
+        let(:a_work) { FactoryGirl.create(default_work_factory_name, user: user) }
+        it "should update the work " do
+          controller.actor = double(:update! => true, :visibility_changed? => false)
+          patch :update, id: a_work
+          response.should redirect_to path_to_curation_concern
+        end
+        describe "changing rights" do
+          it "should prompt to change the files access" do
+            controller.actor = double(:update! => true, :visibility_changed? => true)
+            patch :update, id: a_work
+            response.should redirect_to confirm_curation_concern_permission_path(controller.curation_concern)
+          end
+        end
+      end
+    end
+
+  end
 end

--- a/spec/workers/visibility_copy_worker_spec.rb
+++ b/spec/workers/visibility_copy_worker_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe VisibilityCopyWorker do
 
   describe "an open access work" do
-    let(:work) { FactoryGirl.create(:work_with_files, visibility: Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+    let(:work) { FactoryGirl.create(:generic_work_with_files, visibility: Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
     subject { VisibilityCopyWorker.new(work.id) }
 
     it "should have no content at the outset" do
@@ -19,8 +19,8 @@ describe VisibilityCopyWorker do
   end
 
   describe "an embargoed work" do
-    let(:embargo_date) { 2.days.from_now } 
-    let(:work) { FactoryGirl.create(:work_with_files, visibility: Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, embargo_release_date: embargo_date) }
+    let(:embargo_date) { 2.days.from_now }
+    let(:work) { FactoryGirl.create(:generic_work_with_files, visibility: Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, embargo_release_date: embargo_date) }
     subject { VisibilityCopyWorker.new(work.id) }
 
     it "should have no content at the outset" do


### PR DESCRIPTION
Given that the datasets and generic_works controllers are practially
the same, I want to extract that behavior/meaning into a shared
example.

Closes ndlib/planning#162
