### PR TITLE
Improving the curate:work generator

### DIFF
--- a/lib/generators/curate/work/USAGE
+++ b/lib/generators/curate/work/USAGE
@@ -8,7 +8,9 @@ Example:
     app/repository_models/chicken_pie.rb
     app/repository_datastreams/chicken_pie_metadata_datastream.rb
     app/services/curation_concern/chicken_pie_actor.rb
+    app/controllers/curation_concern/chicken_pies_controller.rb
+    spec/factories/chicken_pie_factory.rb
     spec/repository_models/chicken_pie_spec.rb
     spec/repository_datastreams/chicken_pie_metadata_datastream_spec.rb
     spec/services/curation_concern/chicken_pie_actor_spec.rb
-    spec/factories/chicken_pie_factory.rb
+    spec/controllers/curation_concern/chicken_pies_controller_spec.rb

--- a/lib/generators/curate/work/templates/actor.rb.erb
+++ b/lib/generators/curate/work/templates/actor.rb.erb
@@ -1,6 +1,6 @@
 # Generated via
 #  `rails generate curate:work <%= class_name %>`
 module CurationConcern
-  class <%= class_name %>Actor < CurationConcern::BaseActor
+  class <%= class_name %>Actor < CurationConcern::GenericWorkActor
   end
 end

--- a/lib/generators/curate/work/templates/actor_spec.rb.erb
+++ b/lib/generators/curate/work/templates/actor_spec.rb.erb
@@ -2,21 +2,34 @@
 #  `rails generate curate:work <%= class_name %>`
 require 'spec_helper'
 
-describe <%= class_name %>Actor do
-  let(:user) { User.new }
-  let(:curation_concern) { GenericFile.new }
-  let(:attributes) { {visibility: visibility} }
-  let(:visibility) { nil }
+describe CurationConcern::<%= class_name %>Actor do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:curation_concern) { <%= class_name %>.new }
+  let(:attributes) { {} }
   subject { CurationConcern.actor(curation_concern, user, attributes)}
-  describe 'with visibility "1"' do
-    let(:visibility) { "1" }
-    its(:visibility) { should == visibility }
-    its(:visibility_may_have_changed?) { should == true }
+
+  describe 'create!' do
+    let(:curation_concern) { FactoryGirl.build(:<%= file_name %>) }
+    after(:each) do
+      curation_concern.destroy
+    end
+    it 'should create when valid' do
+      expect {
+        subject.create!
+      }.to change { <%= class_name %>.count }.by(1)
+    end
   end
 
-  describe 'with missing visibility' do
-    let(:visibility) { nil }
-    its(:visibility) { should be_nil }
-    its(:visibility_may_have_changed?) { should == false }
+  describe 'update!' do
+    let(:curation_concern) { FactoryGirl.create(:<%= file_name %>) }
+    let(:attributes) { {title: 'A New Title'} }
+    after(:each) do
+      curation_concern.destroy
+    end
+    it 'should update the file when valid' do
+      expect(subject.update!).to eq true
+      expect(curation_concern.title).to eq attributes.fetch(:title)
+    end
   end
+
 end

--- a/lib/generators/curate/work/templates/controller.rb.erb
+++ b/lib/generators/curate/work/templates/controller.rb.erb
@@ -1,0 +1,6 @@
+# Generated via
+#  `rails generate curate:work <%= class_name %>`
+
+class CurationConcern::<%= class_name.pluralize %>Controller < CurationConcern::GenericWorksController
+  self.curation_concern_type = <%= class_name %>
+end

--- a/lib/generators/curate/work/templates/controller_spec.rb.erb
+++ b/lib/generators/curate/work/templates/controller_spec.rb.erb
@@ -1,0 +1,7 @@
+# Generated via
+#  `rails generate curate:work <%= class_name %>`
+require 'spec_helper'
+
+describe CurationConcern::<%= class_name.pluralize %>Controller do
+  include_examples 'is_a_curation_concern_controller', <%= class_name %>, :all
+end

--- a/lib/generators/curate/work/templates/datastream.rb.erb
+++ b/lib/generators/curate/work/templates/datastream.rb.erb
@@ -1,0 +1,82 @@
+# Generated via
+#  `rails generate curate:work <%= class_name %>`
+class <%= class_name %>RdfDatastream < ActiveFedora::NtriplesRDFDatastream
+
+  map_predicates do |map|
+
+    map.title(in: RDF::DC) do |index|
+      index.as :stored_searchable
+    end
+
+    map.contributor(in: RDF::DC) do |index|
+      index.as :searchable, :facetable, :displayable
+    end
+
+    map.created(in: RDF::DC)
+
+    map.creator(in: RDF::DC) do |index|
+      index.as :stored_searchable, :facetable
+    end
+
+    map.description(in: RDF::DC) do |index|
+      index.type :text
+      index.as :stored_searchable
+    end
+
+    map.subject(in: RDF::DC) do |index|
+      index.type :text
+      index.as :stored_searchable
+    end
+
+    map.date_uploaded(to: "dateSubmitted", in: RDF::DC) do |index|
+      index.type :date
+      index.as :stored_searchable, :sortable
+    end
+
+    map.date_modified(to: "modified", in: RDF::DC) do |index|
+      index.type :date
+      index.as :stored_searchable, :sortable
+    end
+
+    map.issued({in: RDF::DC}) do |index|
+      index.as :stored_searchable
+    end
+
+    map.available({in: RDF::DC})
+
+    map.publisher({in: RDF::DC}) do |index|
+      index.as :stored_searchable, :facetable
+    end
+
+    map.bibliographic_citation({in: RDF::DC, to: 'bibliographicCitation'})
+
+    map.source({in: RDF::DC})
+
+    map.rights(:in => RDF::DC) do |index|
+      index.as :stored_searchable, :facetable
+    end
+
+    map.access_rights({in: RDF::DC, to: 'accessRights'})
+
+    map.language({in: RDF::DC}) do |index|
+      index.as :searchable, :facetable
+    end
+
+    map.archived_object_type({in: RDF::DC, to: 'type'}) do |index|
+      index.as :stored_searchable, :facetable
+    end
+
+    map.content_format({in: RDF::DC, to: 'format'})
+
+    map.extent({in: RDF::DC})
+
+    map.requires({in: RDF::DC})
+
+    map.identifier({in: RDF::DC})
+
+    map.part(:to => "hasPart", in: RDF::DC)
+
+  end
+
+end
+

--- a/lib/generators/curate/work/templates/factory.rb.erb
+++ b/lib/generators/curate/work/templates/factory.rb.erb
@@ -3,11 +3,38 @@
 #
 # Read about factories at https://github.com/thoughtbot/factory_girl
 
-require 'curate/spec_support'
 FactoryGirl.define do
   factory :<%= singular_table_name %>, class: <%= class_name %> do
-<% for attribute in attributes -%>
-    <%= attribute.name %> <%= attribute.default.inspect %>
-<% end -%>
+    ignore do
+      user { FactoryGirl.create(:user) }
+    end
+
+    sequence(:title) {|n| "Title #{n}"}
+    rights { Sufia.config.cc_licenses.keys.first }
+    date_uploaded { Date.today }
+    date_modified { Date.today }
+    visibility Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+
+    before(:create) { |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+      work.creator = evaluator.user.to_s
+    }
+
+    factory :private_<%= singular_table_name %> do
+      visibility Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
+    factory :public_<%= singular_table_name %> do
+      visibility Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    factory :<%= singular_table_name %>_with_files do
+      ignore do
+        file_count 3
+      end
+
+      after(:create) do |work, evaluator|
+        FactoryGirl.create_list(:generic_file, evaluator.file_count, batch: work, user: evaluator.user)
+      end
+    end
   end
 end

--- a/lib/generators/curate/work/templates/model.rb.erb
+++ b/lib/generators/curate/work/templates/model.rb.erb
@@ -1,9 +1,45 @@
 # Generated via
 #  `rails generate curate:work <%= class_name %>`
 require 'active_fedora/base'
+require Rails.root.join('app/repository_datastreams/<%= file_name %>_rdf_datastream')
 class <%= class_name %> < ActiveFedora::Base
   include CurationConcern::Model
   include CurationConcern::WithGenericFiles
   include CurationConcern::Embargoable
+  include ActiveFedora::RegisteredAttributes
+
+  has_metadata "descMetadata", type: <%= class_name %>RdfDatastream
+
+  attribute :title, datastream: :descMetadata,
+    multiple: false,
+    validates: {presence: { message: 'Your work must have a title.' }}
+
+  attribute :rights, datastream: :descMetadata,
+    multiple: false,
+    validates: {presence: { message: 'You must select a license for your work.' }}
+
+  attribute :created, datastream: :descMetadata, multiple: false
+  attribute :description, datastream: :descMetadata, multiple: false
+  attribute :date_uploaded, datastream: :descMetadata, multiple: false
+  attribute :date_modified, datastream: :descMetadata, multiple: false
+  attribute :available, datastream: :descMetadata, multiple: false
+  attribute :archived_object_type, datastream: :descMetadata, multiple: false
+  attribute :creator, datastream: :descMetadata, multiple: false
+  attribute :content_format, datastream: :descMetadata, multiple: false
+  attribute :identifier, datastream: :descMetadata, multiple: false
+
+  attribute :contributor, datastream: :descMetadata, multiple: true
+  attribute :publisher, datastream: :descMetadata, multiple: true
+  attribute :bibliographic_citation, datastream: :descMetadata, multiple: true
+  attribute :source, datastream: :descMetadata, multiple: true
+  attribute :language, datastream: :descMetadata, multiple: true
+  attribute :extent, datastream: :descMetadata, multiple: true
+  attribute :requires, datastream: :descMetadata, multiple: true
+  attribute :subject, datastream: :descMetadata, multiple: true
+
+  attribute :files, multiple: true, form: {as: :file},
+    hint: "CTRL-Click (Windows) or CMD-Click (Mac) to select multiple files."
+
+  attribute :linked_resource_url, multiple: true
 
 end

--- a/lib/generators/curate/work/templates/model_spec.rb.erb
+++ b/lib/generators/curate/work/templates/model_spec.rb.erb
@@ -7,13 +7,33 @@ describe <%= class_name %> do
   include ActiveFedora::TestSupport
   subject { <%= class_name %>.new }
 
-  it 'should persist to Fedora' do
-    subject.save!
-    expect {
-      subject.reload
-    }.to_not raise_error(ActiveFedora::ObjectNotFoundError)
+  include_examples 'with_access_rights'
+  include_examples 'is_embargoable'
+  include_examples 'has_dc_metadata'
 
-    subject.destroy
+  it { should have_unique_field(:archived_object_type) }
+
+  describe 'its test support factories', factory_verification: true do
+    it {
+      expect {
+        FactoryGirl.create(:<%= file_name %>).destroy
+      }.to_not raise_error
+    }
+    it {
+      expect {
+        FactoryGirl.create(:private_<%= file_name %>).destroy
+      }.to_not raise_error
+    }
+    it {
+      expect {
+        FactoryGirl.create(:public_<%= file_name %>).destroy
+      }.to_not raise_error
+    }
+    it {
+      expect {
+        FactoryGirl.create(:<%= file_name %>_with_files).destroy
+      }.to_not raise_error
+    }
   end
 
 end

--- a/lib/generators/curate/work/work_generator.rb
+++ b/lib/generators/curate/work/work_generator.rb
@@ -5,24 +5,45 @@ class Curate::WorkGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("../templates", __FILE__)
 
   desc "Create a Repository Model."
+  argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
 
-  def create_repository_model
-    template "model.rb.erb", "app/repository_models/#{file_name}.rb"
+  # Why all of these antics with defining individual methods?
+  # Because I want the output of Curate::WorkGenerator to include all the processed files.
+  def create_model_spec
     template "model_spec.rb.erb", "spec/repository_models/#{file_name}_spec.rb"
   end
-
-  # def create_controller
-  #   template "controller.rb.erb", "app/controllers/curation_concern/#{plural_file_name}_actor.rb"
-  #   template "controller_spec.rb.erb", "spec/controllers/curation_concern/#{plural_file_name}_actor.rb"
-  # end
-
+  def create_model
+    template("model.rb.erb", "app/repository_models/#{file_name}.rb")
+  end
+  def create_controller_spec
+    template("controller_spec.rb.erb", "spec/controllers/curation_concern/#{plural_file_name}_controller_spec.rb")
+  end
+  def create_actor_spec
+    template("actor_spec.rb.erb", "spec/services/curation_concern/#{file_name}_actor_spec.rb")
+  end
+  def create_factory
+    template("factory.rb.erb", "spec/factories/#{plural_file_name}_factory.rb")
+  end
+  def create_datastream
+    template("datastream.rb.erb", "app/repository_datastreams/#{file_name}_rdf_datastream.rb")
+  end
+  def create_controller
+    template("controller.rb.erb", "app/controllers/curation_concern/#{plural_file_name}_controller.rb")
+  end
   def create_actor
-    template "actor.rb.erb", "app/services/curation_concern/#{file_name}_actor.rb"
-    template "actor_spec.rb.erb", "spec/services/curation_concern/#{file_name}_actor.rb"
+    template("actor.rb.erb", "app/services/curation_concern/#{file_name}_actor.rb")
   end
 
-  def create_factory
-    template "factory.rb.erb", "spec/factories/#{plural_file_name}_factory.rb"
+  def update_routes
+    reg_exp = /^(\s+curate_for\(? *\{? *:?containers:? *=?\>? *\[)([^\]]*)(\] *\}? *\)?)\s*$/
+    gsub_file 'config/routes.rb', reg_exp do |match|
+      match =~ reg_exp
+      # Don't re-add the route
+      if !$2.include?(plural_table_name)
+        match = $1 << $2 << ", :#{plural_table_name}" << $3
+      end
+      match
+    end
   end
 
   # def create_views

--- a/spec/lib/generators/curate/work/work_generator_spec.rb
+++ b/spec/lib/generators/curate/work/work_generator_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+# This is not your standard looking rspec file.
+# It is different in that the generator is being run against the dummy app (i.e. Rails.root in this context).
+# The resulting generated files are then tested as part of this test suite.
+require 'generators/curate/work/work_generator'
+FileUtils.cd(Rails.root)
+response = Curate::WorkGenerator.start(%W(spam --force))
+
+sleep(2) if ENV['TRAVIS'] # Because the generator is not completing
+
+spec_filenames = Array(response).flatten.compact.grep(/spec/)
+
+number_of_expected_spec_files = 3
+if spec_filenames.size < number_of_expected_spec_files
+  banner = "\n" + "*" * 80 + "\n"
+  message = banner
+  message << "The generator response was not as expected; Since this is outside the context of\n"
+  message << "an rspec block, I don't have the usual assertions. Actual response below:\n"
+  message << "\n" << response.inspect << "\n"
+  message << banner
+  raise RuntimeError, message
+end
+
+Rails.application.reload_routes!
+
+spec_filenames.each do |spec_path|
+  file_path = spec_path.gsub(/^spec\/(.*)_spec.rb$/, 'app/\1.rb')
+  require Rails.root.join(file_path) if file_path != spec_path
+  begin
+    require Rails.root.join(spec_path)
+  rescue FactoryGirl::DuplicateDefinitionError => e
+    # No worries, this isn't a big deal
+  end
+end


### PR DESCRIPTION
The previous version was very spotty in what it provides, and while
this is not the definitive version of the curate:work generator it
does provide:
- Controller and corresponding spec generation, highlighting that each
  work type concern is likely very similar to other works, but can
  easily be altered
- Routes are now injected into an existing application
- Added to Curate's test suite is the run-time generation of a work
  model via the curate:work generator and most importantly testing
  that those generated specs actually work

Further refactorings includes, but is not limited to:
- Removing duplication concerning actor specs; Given that works are
  viewed as likely very similar, each actor should have a macro
  for that particular spec.

Closes #156, #157
