### PR TITLE
Adding DatasetsController.curation_concern_type

### DIFF
--- a/app/controllers/curation_concern/articles_controller.rb
+++ b/app/controllers/curation_concern/articles_controller.rb
@@ -1,13 +1,3 @@
 class CurationConcern::ArticlesController < CurationConcern::GenericWorksController
-
-  register :actor do
-    CurationConcern.actor(curation_concern, current_user, params[:article])
-  end
-  register :curation_concern do
-    if params[:id]
-      Article.find(params[:id])
-    else
-      Article.new(params[:article])
-    end
-  end
+  self.curation_concern_type = Article
 end


### PR DESCRIPTION
By specifying the :curation_concern_type, we can remove the need for
explicit declaration of the :actor and :curation_concern

@rbalekai @val99erie 
