### PR TITLE
Replacing README instructions with generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@
 
 * Add `gem 'curate'` to your Gemfile, then run `bundle`
 * Run the generator: `rails generate curate`
-* Run the migrations `rake db:migrate`
-* Remove the generated blacklight css: `rm app/assets/stylesheets/blacklight.css.scss` 
-* In `app/assets/stylesheets/application.css` add this line:
-  ```
-    *= require curate
-  ```
 
 ## Curate Developer Notes
 

--- a/app/assets/stylesheets/blacklight.css.scss
+++ b/app/assets/stylesheets/blacklight.css.scss
@@ -1,6 +1,0 @@
-@import 'style/variables';
-@import 'bootstrap';
-@import 'bootstrap-responsive';
-@import 'font-awesome';
-
-@import 'blacklight/blacklight';

--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -114,4 +114,12 @@ This generator makes the following changes to your application:
     copy_file(src_file, dest_file)
   end
 
+  def remove_blacklight
+    remove_file('app/assets/stylesheets/blacklight.css.scss')
+  end
+
+  def run_migrations
+    rake "db:migrate"
+  end
+
 end


### PR DESCRIPTION
The instructions instructed the developer to execute several steps to
generate a Curate application.

Instead of codifying the expected steps in comments, I am adding those
steps to the `curate` generator.
