### PR TITLE
Adding registry for curation concerns

### DIFF
--- a/app/models/classify_concern.rb
+++ b/app/models/classify_concern.rb
@@ -1,10 +1,5 @@
 require 'active_attr'
 class ClassifyConcern
-  # @TODO - This should be part of the application configuration
-  # or detected on load
-  VALID_CURATION_CONCERN_CLASS_NAMES = [
-    'GenericWork', 'Dataset', 'Article'
-  ]
   UPCOMING_CONCERNS = []
 
   include ActiveAttr::Model
@@ -13,19 +8,15 @@ class ClassifyConcern
   validates(
     :curation_concern_type,
     presence: true,
-    inclusion: { in: lambda { |record| VALID_CURATION_CONCERN_CLASS_NAMES } }
+    inclusion: { in: lambda { |record| record.registered_curation_concern_types } }
   )
 
-  def self.all_curation_concern_classes
-    VALID_CURATION_CONCERN_CLASS_NAMES.collect(&:constantize)
-  end
-
   def all_curation_concern_classes
-    self.class.all_curation_concern_classes
+    registered_curation_concern_types.collect(&:constantize)
   end
 
   def possible_curation_concern_types
-    VALID_CURATION_CONCERN_CLASS_NAMES.collect{|concern|
+    registered_curation_concern_types.collect{|concern|
       [concern.constantize.human_readable_type, concern]
     }
   end
@@ -42,5 +33,11 @@ class ClassifyConcern
 
   def upcoming_concerns
     UPCOMING_CONCERNS
+  end
+
+  require 'morphine'
+  include Morphine
+  register :registered_curation_concern_types do
+    Curate.configuration.registered_curation_concern_types
   end
 end

--- a/lib/curate/configuration.rb
+++ b/lib/curate/configuration.rb
@@ -12,22 +12,37 @@ module Curate
     # An anonymous function that receives a path to a file
     # and returns AntiVirusScanner::NO_VIRUS_FOUND_RETURN_VALUE if no
     # virus is found; Any other returned value means a virus was found
-    attr_accessor :default_antivirus_instance
+    attr_writer :default_antivirus_instance
+    def default_antivirus_instance
+      @default_antivirus_instance ||= lambda {|file_path|
+        AntiVirusScanner::NO_VIRUS_FOUND_RETURN_VALUE
+      }
+    end
+
 
     # When was this last built/deployed
-    attr_accessor :build_identifier
+    attr_writer :build_identifier
+    def build_identifier
+      # If you restart the server, this could be out of sync; A better
+      # implementation is to read something from the file system. However
+      # that detail is an exercise for the developer.
+      @build_identifier ||= Time.now.strftime("%Y-%m-%d %H:%M:%S")
+    end
 
     # Override characterization runner
     attr_accessor :characterization_runner
 
-    def initialize
-      @default_antivirus_instance = lambda {|file_path|
-        AntiVirusScanner::NO_VIRUS_FOUND_RETURN_VALUE
-      }
-      # If you restart the server, this could be out of sync; A better
-      # implementation is to read something from the file system. However
-      # that detail is an exercise for the developer.
-      @build_identifier = Time.now.strftime("%Y-%m-%d %H:%M:%S")
+    def register_curation_concern(*curation_concern_types)
+      Array(curation_concern_types).flatten.compact.each do |cc_type|
+        class_name = cc_type.to_s.classify
+        if ! registered_curation_concern_types.include?(class_name)
+          self.registered_curation_concern_types << class_name
+        end
+      end
+    end
+
+    def registered_curation_concern_types
+      @registered_curation_concern_types ||= []
     end
   end
 

--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -71,12 +71,28 @@ This generator makes the following changes to your application:
     end
   end
 
+  DEFAULT_CURATION_CONCERNS = [:generic_works, :datasets, :articles]
+
   # The engine routes have to come after the devise routes so that /users/sign_in will work
   def inject_routes
-    routing_code = "\n  curate_for containers: [:generic_works, :datasets, :articles]\n"
+    routing_code = "\n  curate_for containers: #{DEFAULT_CURATION_CONCERNS.inspect}\n"
     sentinel = /devise_for +:users.*$/
     inject_into_file 'config/routes.rb', routing_code, { :after => sentinel, :verbose => false }
     gsub_file 'config/routes.rb', /^\s+root.+$/, "  root 'welcome#index'"
+  end
+
+  def create_curate_initializer
+    initializer 'curate_config.rb' do
+      data = []
+
+      data << "Curate.configure do |config|"
+      DEFAULT_CURATION_CONCERNS.each do |curation_concern|
+        data << "  config.register_curation_concern :#{curation_concern.to_s.singularize}"
+      end
+      data << "end"
+
+      data.join("\n")
+    end
   end
 
   # This enables our registrations controller to run the after_update_path_for hook.

--- a/lib/generators/curate/work/templates/model_spec.rb.erb
+++ b/lib/generators/curate/work/templates/model_spec.rb.erb
@@ -7,33 +7,9 @@ describe <%= class_name %> do
   include ActiveFedora::TestSupport
   subject { <%= class_name %>.new }
 
+  include_examples 'is_a_curation_concern_model'
   include_examples 'with_access_rights'
   include_examples 'is_embargoable'
   include_examples 'has_dc_metadata'
-
-  it { should have_unique_field(:archived_object_type) }
-
-  describe 'its test support factories', factory_verification: true do
-    it {
-      expect {
-        FactoryGirl.create(:<%= file_name %>).destroy
-      }.to_not raise_error
-    }
-    it {
-      expect {
-        FactoryGirl.create(:private_<%= file_name %>).destroy
-      }.to_not raise_error
-    }
-    it {
-      expect {
-        FactoryGirl.create(:public_<%= file_name %>).destroy
-      }.to_not raise_error
-    }
-    it {
-      expect {
-        FactoryGirl.create(:<%= file_name %>_with_files).destroy
-      }.to_not raise_error
-    }
-  end
 
 end

--- a/lib/generators/curate/work/work_generator.rb
+++ b/lib/generators/curate/work/work_generator.rb
@@ -46,6 +46,15 @@ class Curate::WorkGenerator < Rails::Generators::NamedBase
     end
   end
 
+  def register_work
+    inject_into_file 'config/initializers/curate_config.rb', after: "Curate.configure do |config|\n" do
+      data = ""
+      data << "  # Injected via `rails g curate:work #{class_name}`\n"
+      data << "  config.register_curation_concern :#{file_name}\n"
+      data
+    end
+  end
+
   # def create_views
   # end
 end

--- a/spec/lib/curate/configuration_spec.rb
+++ b/spec/lib/curate/configuration_spec.rb
@@ -1,28 +1,13 @@
 require 'spec_helper'
 module Curate
   describe Configuration do
+    its(:default_antivirus_instance) { should respond_to(:call)}
     its(:build_identifier) { should be_an_instance_of String }
-    describe '#default_antivirus_instance' do
-      before(:each) do
-        @previous_av_instance = Curate.configuration.default_antivirus_instance
-      end
-      after(:each) do
-        Curate.configuration.default_antivirus_instance = @previous_av_instance
-      end
-      it 'has a default callable' do
-        expect(Curate.configuration.default_antivirus_instance.call(__FILE__)).
-          to eq(AntiVirusScanner::NO_VIRUS_FOUND_RETURN_VALUE)
-      end
+    it 'allow for registration of curation_concerns' do
+      expect {
+        subject.register_curation_concern(:generic_work)
+      }.to change{ subject.registered_curation_concern_types }.from([]).to(['GenericWork'])
 
-      it 'is configurable' do
-        Curate.configure do |config|
-          config.default_antivirus_instance = lambda {|path|
-            '2'
-          }
-        end
-        expect(Curate.configuration.default_antivirus_instance.call(__FILE__)).
-          to eq("2")
-      end
     end
   end
 end

--- a/spec/lib/generators/curate/work/work_generator_spec.rb
+++ b/spec/lib/generators/curate/work/work_generator_spec.rb
@@ -22,7 +22,10 @@ if spec_filenames.size < number_of_expected_spec_files
   raise RuntimeError, message
 end
 
+# Because we are adding things to stuff that was already initialized
+# (i.e. routes and initializers)
 Rails.application.reload_routes!
+load Rails.root.join('config/initializers/curate_config.rb')
 
 spec_filenames.each do |spec_path|
   file_path = spec_path.gsub(/^spec\/(.*)_spec.rb$/, 'app/\1.rb')

--- a/spec/models/classify_concern_spec.rb
+++ b/spec/models/classify_concern_spec.rb
@@ -3,34 +3,14 @@ require 'spec_helper'
 describe ClassifyConcern do
   subject { ClassifyConcern.new(curation_concern_type: curation_concern_type) }
   let(:curation_concern_type) { nil }
-
-  describe '.all_curation_concern_classes' do
-    it 'has GenericWork' do
-      expect(ClassifyConcern.all_curation_concern_classes).to include(GenericWork)
-      expect(ClassifyConcern.all_curation_concern_classes).to_not include('GenericWork')
-    end
-    it 'has Dataset' do
-      expect(ClassifyConcern.all_curation_concern_classes).to include(Dataset)
-      expect(ClassifyConcern.all_curation_concern_classes).to_not include('Dataset')
-    end
-    it 'has Article' do
-      expect(ClassifyConcern.all_curation_concern_classes).to include(Article)
-      expect(ClassifyConcern.all_curation_concern_classes).to_not include('Article')
-    end
+  before(:each) do
+    subject.registered_curation_concern_types = ['GenericWork']
   end
-
-  describe '#all_curation_concern_classes' do
-    it 'relies on the list from ClassifyConcern Class' do
-      expect(subject.all_curation_concern_classes).to eql(ClassifyConcern.all_curation_concern_classes)
-    end
-  end
-
+  its(:all_curation_concern_classes) { should include(GenericWork)}
+  its(:all_curation_concern_classes) { should_not include('GenericWork')}
 
   describe 'with curation_concern_type: nil' do
-    it 'is not valid' do
-      expect(subject).to_not be_valid
-    end
-
+    it { should_not be_valid}
     it 'raises an error on .curation_concern_class' do
       expect{
         subject.curation_concern_class
@@ -40,14 +20,8 @@ describe ClassifyConcern do
 
   describe 'with curation_concern_type: "GenericWork"' do
     let(:curation_concern_type) { "GenericWork" }
-
-    it 'is valid if curation_concern_type is from the right list' do
-      expect(subject).to be_valid
-    end
-
-    it 'has a <GenericWork> class for curation_concern_class' do
-      expect(subject.curation_concern_class).to eq(GenericWork)
-    end
+    it { should be_valid}
+    its(:curation_concern_class) { should eq(GenericWork) }
   end
 
   describe '#upcoming_concerns' do

--- a/spec/repository_models/dataset_spec.rb
+++ b/spec/repository_models/dataset_spec.rb
@@ -3,12 +3,11 @@ require 'spec_helper'
 describe Dataset do
   subject { Dataset.new }
 
+  include_examples 'is_a_curation_concern_model'
   include_examples 'with_access_rights'
   include_examples 'is_embargoable'
   include_examples 'has_dc_metadata'
 
   it { should have_unique_field(:available) }
-  it { should have_unique_field(:archived_object_type) }
-
 
 end

--- a/spec/support/curation_concern/factory_helpers.rb
+++ b/spec/support/curation_concern/factory_helpers.rb
@@ -1,0 +1,14 @@
+module CurationConcern
+  module FactoryHelpers
+    module_function
+    def load_factories_for(context, klass)
+      context.instance_exec(klass) do |curation_concern_class|
+        let(:curation_concern_type_underscore) { curation_concern_class.name.underscore }
+        let(:default_work_factory_name) { curation_concern_type_underscore }
+        let(:default_work_factory_name_with_files) { "#{default_work_factory_name}_with_files".to_sym }
+        let(:private_work_factory_name) { "private_#{curation_concern_type_underscore}".to_sym }
+        let(:public_work_factory_name) { "public_#{curation_concern_type_underscore}".to_sym }
+      end
+    end
+  end
+end

--- a/spec/support/shared/shared_examples_is_a_curation_concern_actor.rb
+++ b/spec/support/shared/shared_examples_is_a_curation_concern_actor.rb
@@ -1,13 +1,8 @@
 shared_examples 'is_a_curation_concern_actor' do |curation_concern_class|
+  CurationConcern::FactoryHelpers.load_factories_for(self, curation_concern_class)
   include ActionDispatch::TestProcess
   let(:user) { FactoryGirl.create(:user) }
   let(:file) { fixture_file_upload('/files/image.png', 'image/png') }
-
-  let(:curation_concern_type_underscore) { curation_concern_class.name.underscore }
-  let(:default_work_factory_name) { curation_concern_type_underscore }
-  let(:private_work_factory_name) { "private_#{curation_concern_type_underscore}".to_sym }
-  let(:public_work_factory_name) { "public_#{curation_concern_type_underscore}".to_sym }
-
 
   subject {
     CurationConcern.actor(curation_concern, user, attributes)

--- a/spec/support/shared/shared_examples_is_a_curation_concern_controller.rb
+++ b/spec/support/shared/shared_examples_is_a_curation_concern_controller.rb
@@ -1,19 +1,16 @@
-shared_examples 'is_a_curation_concern_controller' do |collection_class, actions = :all|
+shared_examples 'is_a_curation_concern_controller' do |curation_concern_class, actions = :all|
+  CurationConcern::FactoryHelpers.load_factories_for(self, curation_concern_class)
+
   def self.optionally_include_specs(actions, action_name)
     normalized_actions = Array(actions).flatten.compact
     return true if normalized_actions.include?(:all)
     return true if normalized_actions.include?(action_name.to_sym)
     return true if normalized_actions.include?(action_name.to_s)
   end
-  its(:curation_concern_type) { should eq collection_class }
+  its(:curation_concern_type) { should eq curation_concern_class }
 
   let(:user) { FactoryGirl.create(:user) }
   before { sign_in user }
-
-  let(:curation_concern_type_underscore) { collection_class.name.underscore }
-  let(:default_work_factory_name) { curation_concern_type_underscore }
-  let(:private_work_factory_name) { "private_#{curation_concern_type_underscore}".to_sym }
-  let(:public_work_factory_name) { "public_#{curation_concern_type_underscore}".to_sym }
 
   def path_to_curation_concern
     public_send("curation_concern_#{curation_concern_type_underscore}_path", controller.curation_concern)

--- a/spec/support/shared/shared_examples_is_a_curation_concern_model.rb
+++ b/spec/support/shared/shared_examples_is_a_curation_concern_model.rb
@@ -1,0 +1,33 @@
+shared_examples 'is_a_curation_concern_model' do 
+  CurationConcern::FactoryHelpers.load_factories_for(self, described_class)
+
+  it 'is registered for classification' do
+    expect(Curate.configuration.registered_curation_concern_types).to include(described_class.name)
+  end
+
+  it { should have_unique_field(:archived_object_type) }
+
+  describe 'its test support factories', factory_verification: true do
+    it {
+      expect {
+        FactoryGirl.create(default_work_factory_name).destroy
+      }.to_not raise_error
+    }
+    it {
+      expect {
+        FactoryGirl.create(private_work_factory_name).destroy
+      }.to_not raise_error
+    }
+    it {
+      expect {
+        FactoryGirl.create(public_work_factory_name).destroy
+      }.to_not raise_error
+    }
+    it {
+      expect {
+        FactoryGirl.create(default_work_factory_name).destroy
+      }.to_not raise_error
+    }
+  end
+
+end


### PR DESCRIPTION
Instead of relying on updating a constant, Curate now provides a
configuration option for registering new curation_concerns.

This also involved adjusting the `curate` and `curate:work`
generators. The registration occurs in an initializer.

A refactoring was also done to eliminate the duplicate behavior
regarding factory names and the shared examples.
