### PR TITLE
Adding README to `curate:work` generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 * Add `gem 'curate'` to your Gemfile, then run `bundle`
 * Run the generator: `rails generate curate`
+* Run the following: `rails generate curate:work -h`; You may want to see how to create and register new works.
 
 ## Curate Developer Notes
 

--- a/lib/generators/curate/work/USAGE
+++ b/lib/generators/curate/work/USAGE
@@ -1,5 +1,6 @@
 Description:
-  This generator provides a means of creating a container
+  This generator creates the necessary files for work that extends
+  Curate's GenericWork.
 
 Example:
   rails generate curate:work ChickenPie
@@ -9,8 +10,12 @@ Example:
     app/repository_datastreams/chicken_pie_metadata_datastream.rb
     app/services/curation_concern/chicken_pie_actor.rb
     app/controllers/curation_concern/chicken_pies_controller.rb
+    app/views/curation_concern/chicken_pies/.keep
     spec/factories/chicken_pie_factory.rb
     spec/repository_models/chicken_pie_spec.rb
     spec/repository_datastreams/chicken_pie_metadata_datastream_spec.rb
     spec/services/curation_concern/chicken_pie_actor_spec.rb
     spec/controllers/curation_concern/chicken_pies_controller_spec.rb
+
+  This will also:
+    register ChickenPie as a valid curation concern

--- a/lib/generators/curate/work/templates/README
+++ b/lib/generators/curate/work/templates/README
@@ -1,0 +1,13 @@
+===============================================================================
+
+After creating your work you may wish to:
+
+  1. Add custom views:
+
+      Your newly created work's controller extends from
+      CurationConcern::GenericWorksController; This means that it will use the
+      views of found in Curate::Engine.root/app/views/curation_concern/generic_works.
+
+  2. Modify the model and datastreams
+
+===============================================================================

--- a/lib/generators/curate/work/work_generator.rb
+++ b/lib/generators/curate/work/work_generator.rb
@@ -4,7 +4,6 @@ require 'rails/generators'
 class Curate::WorkGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("../templates", __FILE__)
 
-  desc "Create a Repository Model."
   argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
 
   # Why all of these antics with defining individual methods?
@@ -55,6 +54,12 @@ class Curate::WorkGenerator < Rails::Generators::NamedBase
     end
   end
 
-  # def create_views
-  # end
+  def create_views
+    create_file("app/views/curation_concern/#{plural_file_name}/.keep")
+  end
+
+  def create_readme
+    readme 'README'
+  end
+
 end


### PR DESCRIPTION
The curate:work generator is how we can easily and quickly create new
types of work. As such, I want the usage to be as clear as possible,
and highlight potential next steps.
