### PR TITLE
refs #111 Dashboard can handle results that are not curation concerns (i.e. collections)

### DIFF
--- a/app/helpers/curate_helper.rb
+++ b/app/helpers/curate_helper.rb
@@ -52,7 +52,7 @@ module CurateHelper
 
   def link_to_edit_permissions(curation_concern, solr_document = nil)
     markup = <<-HTML
-      <a href="#{edit_polymorphic_path([:curation_concern, curation_concern])}" id="permission_#{curation_concern.to_param}">
+      <a href="#{edit_polymorphic_path(polymorphic_path_args(curation_concern))}" id="permission_#{curation_concern.to_param}">
         #{permission_badge_for(curation_concern, solr_document)}
       </a>
     HTML
@@ -64,6 +64,21 @@ module CurateHelper
     dom_label_class, link_title = extract_dom_label_class_and_link_title(solr_document)
     %(<span class="label #{dom_label_class}" title="#{link_title}">#{link_title}</span>).html_safe
   end
+
+  def polymorphic_path_args(asset)
+    if Curate.configuration.registered_curation_concern_types.include? asset.class.inspect
+      return [:curation_concern, asset]
+    else
+      return asset
+    end
+  end
+  def polymorphic_path_for_asset(asset)
+    return polymorphic_path(polymorphic_path_args(asset))
+  end
+  def edit_polymorphic_path_for_asset(asset)
+    return edit_polymorphic_path(polymorphic_path_args(asset))
+  end
+
 
   def extract_dom_label_class_and_link_title(document)
     hash = document.stringify_keys

--- a/app/views/dashboard/_index_partials/_list_files.html.erb
+++ b/app/views/dashboard/_index_partials/_list_files.html.erb
@@ -1,12 +1,13 @@
 <% noid = document.noid %>
+
 <tr id="document_<%= noid %>" class="<%= cycle("","zebra") %>">
-  <% gf = ActiveFedora::Base.load_instance_from_solr(document.id) %>
+  <%- gf = ActiveFedora::Base.load_instance_from_solr(document.id) %>
   <td>
     <a href="" title="Click for more details"><i id="expand_<%= noid %>" class="icon-plus icon-large fleft show-details"></i></a>&nbsp;
     <%= render :partial => 'dashboard/_index_partials/thumbnail_display', :locals => {:document=>document} %>
-    <span class="center"><%= link_to gf, polymorphic_path([:curation_concern, gf]), :id => "src_copy_link_#{noid}" %> <br /></span>
+    <span class="center"><%= link_to gf, polymorphic_path_for_asset(gf), :id => "src_copy_link_#{noid}" %> <br /></span>
   </td>
-  <td><%= gf.human_readable_type %></td>
+  <td><%#= gf.human_readable_type %></td>
   <td width="17%"><%= gf.date_uploaded%></td>
   <td width="5%">
     <%= link_to_edit_permissions(gf, document) %>
@@ -15,13 +16,13 @@
   <td width="23%" class="inline-item-actions">
     <%= link_to(
       raw('<i class="icon-pencil icon-large"></i>'),
-      edit_polymorphic_path([:curation_concern, gf]),
+      edit_polymorphic_path_for_asset(gf),
       :class=> 'itemicon itemedit',
       :title => 'Edit File'
     ) if can? :edit, gf %>
     <%= link_to(
       raw('<i class="icon-trash icon-large"></i>'),
-      polymorphic_path([:curation_concern, gf]),
+      edit_polymorphic_path_for_asset(gf),
       :class=> 'itemicon itemtrash',
       :title => %(Delete #{gf.to_s.inspect}),
       :method => :delete,


### PR DESCRIPTION
stopgap until we have time to decide how routes & namespaces should be handled for curation concerns and other items in the dashboard.
