### PR TITLE
Extracting user creation callbacks

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,8 +3,18 @@ class RegistrationsController < Devise::RegistrationsController
   with_themed_layout '1_column'
 
   protected
-    def after_update_path_for(resource)
-      resource.update_column(:user_does_not_require_profile_update, true)
-      super
-    end
+
+  def after_update_path_for(resource)
+    resource.update_column(:user_does_not_require_profile_update, true)
+    super
+  end
+
+  def resource_class
+    Account
+  end
+
+  def sign_up(resource_name, resource)
+    sign_in(resource_name, resource.user)
+  end
+
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,0 +1,176 @@
+class Account
+  # The nastiness that allows us to treat the Account as a User
+  include Curate::DeviseUserShim
+  self.wrapped_class = User
+
+  def inspect
+    "#<#{self.class} user.id: #{user.id}, user.repository_id: #{user.repository_id}, attributes: #{attributes.inspect}>"
+  end
+
+  def is_a?(comparison)
+    super || user.is_a?(comparison)
+  end
+
+  include ActiveAttr::Model
+
+  def initialize(user, attributes = user.attributes)
+    @user = user
+    self.attributes = attributes
+  end
+
+  attr_reader :user
+  def person
+    @person ||= Person.new(name: user.name)
+  end
+
+  def profile
+    @profile ||= Collection.new(title: person.name, resource_type: "Profile")
+  end
+
+  class_attribute :person_attribute_names
+  self.person_attribute_names = []
+  class_attribute :user_attribute_names
+  self.user_attribute_names = User.attribute_names + ['password', 'password_confirmation', 'current_password']
+
+  def self.apply_person_attributes
+    Person.editable_attributes.each do |att|
+      self.person_attribute_names += [att.name.to_s]
+      attribute(att.name)
+      att.with_validation_options do |name, opts|
+        validates(name, opts)
+      end
+    end
+  end
+
+  def self.apply_user_attributes
+    user_attribute_names.each do |attribute_name|
+      attribute(attribute_name)
+    end
+  end
+
+  apply_person_attributes
+  apply_user_attributes
+
+  def create
+    if create_user &&
+        create_person &&
+        create_profile &&
+        connect_user_to_person &&
+        connect_person_to_profile
+      true
+    else
+      collect_errors
+    end
+  end
+  # Create is indicative of what is happening, however Devise calls #save
+  alias save create
+
+  def collect_errors
+    user.errors.each do |key, value|
+      errors.add(key, value)
+    end
+    person.errors.each do |key, value|
+      errors.add(key, value)
+    end
+  end
+  protected :collect_errors
+
+  def update_with_password(initial_params, *options)
+    params = normalize_update_params(initial_params)
+    extract_user_and_person_attributes_for_update(params)
+    if user.update_with_password(user_attributes, *options) &&
+      user.person.update(person_attributes)
+      true
+    else
+      collect_errors
+      false
+    end
+  end
+
+  delegate :persisted?, :to_param, :to_key, :new_record?, to: :user
+
+  def method_missing(method_name, *args, &block)
+    begin
+      super
+    rescue NoMethodError
+      user.send(method_name, *args, &block)
+    end
+  end
+
+  def respond_to_missing?(*args)
+    super || user.respond_to?(*args)
+  end
+
+  private
+
+  def normalize_update_params(params)
+    options = params.dup.with_indifferent_access
+    ['password', 'password_confirmation'].each do |key|
+      if options.has_key?(key) && options[key].empty?
+        options.delete(key)
+      end
+    end
+    options
+  end
+
+  def create_profile
+    apply_deposit_authorization(profile)
+    profile.save!
+  end
+
+  def create_user
+    user.attributes = user_attributes
+    user.save
+  end
+
+  def create_person
+    person.attributes = person_attributes
+    apply_deposit_authorization(person)
+    person.save
+  end
+
+  def apply_deposit_authorization(target)
+    target.apply_depositor_metadata(user.user_key)
+    target.read_groups = [Sufia::Models::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC]
+    target
+  end
+
+  def connect_user_to_person
+    user.update_column(:repository_id, person.pid)
+  end
+
+  def connect_person_to_profile
+    person.profile = profile
+    person.save
+  end
+
+  def user_attributes
+    unless @user_attributes
+      extract_user_and_person_attributes_for_update
+    end
+    @user_attributes
+  end
+
+  def person_attributes
+    unless @person_attributes
+      extract_user_and_person_attributes_for_update
+    end
+    @person_attributes
+  end
+
+  def extract_user_and_person_attributes_for_update(from_attributes = attributes)
+    @user_attributes = {}.with_indifferent_access
+    @person_attributes = {}.with_indifferent_access
+    from_attributes.each_pair do |key, value|
+      if !value.nil?
+        if person_attribute_names.include?(key.to_s)
+          @person_attributes[key] = value
+        end
+        if user_attribute_names.include?(key.to_s)
+          @user_attributes[key] = value
+        end
+      end
+    end
+  end
+
+end

--- a/app/models/curate/devise_user_shim.rb
+++ b/app/models/curate/devise_user_shim.rb
@@ -1,0 +1,65 @@
+module Curate
+  #
+  # Here there be Dragons!
+  #
+  # These are the methods, to the best of my ability, that are necessary to
+  # use the base class as a replacement for User.
+  #
+  # Why might we want to do this?
+  # Because who knows what all needs to happen when a user is created, and we
+  # want to detangle the user creation/maintenance process.
+  #
+  module DeviseUserShim
+    extend ActiveSupport::Concern
+
+
+    def wrapping_class
+      @wrapping_class
+    end
+
+    def wrapping_class=(value)
+      @wrapping_class = value
+    end
+    module_function :wrapping_class, :wrapping_class=
+
+
+    included do
+      class_attribute :wrapped_class
+      DeviseUserShim.wrapping_class = self
+    end
+
+    # Because Devise is violating the Law of Demeter via the following line:
+    # `resource_class.to_adapter.get!(*args)` we have this wonderful work around
+    module ToAdaptorShim
+      def get!(*args)
+        DeviseUserShim.wrapping_class.new(super(*args))
+      end
+    end
+
+    module ClassMethods
+
+      def is_a?(comparison)
+        super || wrapped_class.is_a?(comparison)
+      end
+
+      def devise
+        wrapped_class.devise
+      end
+
+      def authentication_keys
+        wrapped_class.authentication_keys
+      end
+
+      def new_with_session(attributes, session)
+        user = wrapped_class.new_with_session({}, session)
+        new(user, attributes)
+      end
+
+      def to_adapter
+        adapter = wrapped_class.to_adapter
+        adapter.extend(ToAdaptorShim)
+        adapter
+      end
+    end
+  end
+end

--- a/app/models/curate/user/base.rb
+++ b/app/models/curate/user/base.rb
@@ -1,7 +1,10 @@
 module Curate
   module User
     module Base
-
+      extend ActiveSupport::Concern
+      included do
+        alias_attribute :name, :display_name
+      end
       def agree_to_terms_of_service!
         update_column(:agreed_to_terms_of_service, true)
       end

--- a/app/models/curate/user/with_associated_person.rb
+++ b/app/models/curate/user/with_associated_person.rb
@@ -4,76 +4,25 @@ module Curate
       extend ActiveSupport::Concern
 
       included do
-        # Every User has an associated Person record in Fedora
-        after_commit :update_person, on: [:create, :update]
-        after_create :create_person_with_profile
-        delegate :date_of_birth, :gender, :title,
-          :campus_phone_number, :alternate_phone_number,
-          :personal_webpage, :blog, :preferred_email,
-          :profile,
-          to: :person
-        delegate :date_of_birth=, :gender=, :title=,
-          :campus_phone_number=, :alternate_phone_number=,
-          :personal_webpage=, :blog=, :preferred_email=,
-          to: :person
+        person_attributes_not_already_on_base =
+          Person.registered_attribute_names - attribute_names
+
+        person_attributes_not_already_on_base.each do |attribute_name|
+          delegate attribute_name, to: :person
+        end
       end
 
-      def create_person_with_profile
-        person.create_profile(self)
+      def reload
+        @person = nil
+        super
       end
-      private :create_person_with_profile
 
       def person
-        @person ||= if self.repository_id
-          Person.find(self.repository_id)
+        if self.repository_id
+          @person ||= Person.find(self.repository_id)
         else
-          create_person
+          Person.new
         end
-      end
-
-      # Make a new person object and populate it.
-      # Must be careful since when we update ourselves with a link to the new
-      # person object, we will trigger a callback to save the person
-      # object (again).
-      def create_person
-        person = Person.new
-        yield if block_given?
-        person.alternate_email = email
-        person.apply_depositor_metadata(self.user_key)
-        person.read_groups = [Sufia::Models::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC]
-        person.save!
-        self.repository_id = person.pid
-        self.save
-        person
-      end
-      private :create_person
-
-      def update_person
-        person.save
-      end
-      protected :update_person
-
-      def display_name
-        @display_name ||= self.attributes['display_name'] || person.name
-      end
-
-      def display_name=(display_name)
-        write_attribute(:display_name, display_name)
-        person.name= display_name
-      end
-
-      alias_method :name, :display_name
-      alias_method :name=, :display_name=
-
-      def alternate_email
-        if person.blank? || person.alternate_email.blank?
-          return email
-        end
-        person.alternate_email
-      end
-
-      def alternate_email=(alternate_email)
-        person.alternate_email = alternate_email
       end
 
     end

--- a/app/repository_models/person.rb
+++ b/app/repository_models/person.rb
@@ -60,17 +60,4 @@ class Person < ActiveFedora::Base
     persisted? ? User.where(repository_id: pid).first : nil
   end
 
-  # Create associated Profile (which is a Collection object)
-  # Note: marks the profile with resource_type "Profile" (default is Collection) so it can be displayed in Search Results and Facets
-  #   as a Profile instead of a Collection.
-  def create_profile(depositor)
-    collection = Collection.new(title: self.name, resource_type: "Profile")
-    collection.apply_depositor_metadata(depositor.user_key)
-    collection.read_groups = [Sufia::Models::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC]
-    collection.save!
-    self.profile = collection
-    self.save!
-    self.profile
-  end
-
 end

--- a/curate.gemspec
+++ b/curate.gemspec
@@ -49,4 +49,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'jettywrapper'
+  s.add_development_dependency 'database_cleaner', '< 1.1.0'
+  s.add_development_dependency 'poltergeist'
 end

--- a/lib/curate/spec_support.rb
+++ b/lib/curate/spec_support.rb
@@ -7,5 +7,28 @@ require 'rspec/rails'
 require 'rspec-html-matchers'
 require 'rspec/autorun'
 require 'factory_girl'
+require 'capybara/poltergeist'
 Dir["#{spec_directory}/factories/**/*.rb"].each { |f| require f }
 Dir["#{spec_directory}/support/**/*.rb"].each { |f| require f }
+
+Capybara.register_driver :poltergeist_debug do |app|
+  Capybara::Poltergeist::Driver.new(app, :inspector => true)
+end
+
+module FeatureSupport
+  module_function
+  def options(default = {type: :feature})
+    if ENV['JS']
+      Capybara.javascript_driver = default.fetch(:javascript_driver, :poltergeist_debug)
+      default[:js] = true
+    else
+      Capybara.javascript_driver = default.fetch(:javascript_driver, :poltergeist)
+    end
+
+    if ENV['LOCAL']
+      Capybara.current_driver = default.fetch(:javascript_driver, :poltergeist_debug)
+    end
+    default
+  end
+end
+

--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -97,7 +97,9 @@ This generator makes the following changes to your application:
 
   # This enables our registrations controller to run the after_update_path_for hook.
   def update_devise_route
-    gsub_file 'config/routes.rb', /^\s+devise_for :users\s*$/, '  devise_for :users, controllers: { sessions: :sessions, registrations: :registrations }'
+    gsub_file 'config/routes.rb', /^\s+devise_for :users\s*$/ do
+      %(    devise_for :users, controllers: { sessions: :sessions, registrations: :registrations}\n\n)
+    end
   end
 
 

--- a/lib/generators/curate/templates/views/devise/registrations/edit.html.erb
+++ b/lib/generators/curate/templates/views/devise/registrations/edit.html.erb
@@ -2,7 +2,7 @@
   <h1>Account Details</h1>
 <% end %>
 
-<%= simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put }) do |f| %>
+<%= simple_form_for(resource, :as => resource_name, :url => user_registration_path, :html => { :method => :put }) do |f| %>
   <% if f.error_notification -%> 
     <div class="alert alert-error fade in">
       <strong>Wait don't go!</strong> There was a problem with your submission. Please review the errors below:
@@ -32,7 +32,6 @@
       <% end %>
 
       <%= f.input :email,           as: :email, required: true %>
-      <%= f.input :preferred_email, as: :email %>
       <%= f.input :alternate_email, as: :email %>
 
       <%= f.input :campus_phone_number,    as: :tel %>
@@ -76,7 +75,7 @@
 
 <div class="row">
   <div class="span12 form-actions">
-    <%= button_to "Cancel My Account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: 'btn btn-danger' %>
+    <%= button_to "Cancel My Account", cancel_registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: 'btn btn-danger' %>
   </div>
 </div>
 

--- a/spec/controllers/curate/people_controller_spec.rb
+++ b/spec/controllers/curate/people_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Curate::PeopleController do
-  let!(:user) { FactoryGirl.create(:user) }
-  let!(:person) { user.person }
+  let(:person) { FactoryGirl.create(:person_with_user) }
+  let(:user) { person.user }
   let(:a_different_user) { FactoryGirl.create(:user) }
 
   describe "#show" do

--- a/spec/curate/internal/factories.rb
+++ b/spec/curate/internal/factories.rb
@@ -1,0 +1,24 @@
+# This is hear because it cannot be part of spec_support as other
+# Curate based apps would very likely register a :user
+FactoryGirl.define do
+  factory :user do
+    sequence(:email) {|n| "email-#{srand}@test.com" }
+    sequence(:name) {|n| "User Named #{n}" }
+    agreed_to_terms_of_service true
+    user_does_not_require_profile_update true
+    password 'a password'
+    password_confirmation 'a password'
+    sign_in_count 20
+  end
+
+  factory :account do
+    user { FactoryGirl.build(:user) }
+    sequence(:email) {|n| "email-#{srand}@test.com" }
+    initialize_with {|*args|
+      new( user )
+    }
+    after(:create) do |account, evaluator|
+      account.save
+    end
+  end
+end

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -8,8 +8,10 @@ FactoryGirl.define do
   end
   factory :person_with_user, class: Person do
     initialize_with {
-      user = FactoryGirl.create(:user)
-      user.person
+      user = FactoryGirl.build(:user)
+      account = Account.new(user)
+      account.save
+      account.person
     }
   end
 end

--- a/spec/features/person_profile_spec.rb
+++ b/spec/features/person_profile_spec.rb
@@ -3,12 +3,14 @@ require 'spec_helper'
 describe 'Profile for a Person: ' do
 
   context 'logged in user' do
-    let(:user) { FactoryGirl.create(:user) }
+    let(:account) { FactoryGirl.create(:account) }
+    let(:user) { account.user }
+    let(:person) { account.person }
     before { login_as(user) }
 
     it 'will see a link to their profile in the nav' do
       visit dashboard_index_path
-      page.should have_link("Profile", href: person_path(user.person))
+      page.should have_link("Profile", href: person_path(account.person))
     end
   end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper'
+
+describe Account do
+  let(:name) { 'Bilbo Baggins' }
+  let(:user) { FactoryGirl.build(:user) }
+  subject { Account.new(user) }
+
+  its(:inspect) { should include("#<Account user.id: #{user.id}, user.repository_id: #{user.repository_id}") }
+
+  describe 'class methods' do
+    subject { Account }
+    its(:inspect) { should match /\AAccount/ }
+
+    describe '.attribute_names' do
+      subject { Account.attribute_names }
+      its(:length) { should be > 5}
+    end
+
+    describe '.new_with_session' do
+      let(:attributes) { { name: name } }
+      let(:session) { {} }
+      subject { Account.new_with_session(attributes, session) }
+      its(:name) { should == name }
+      it { should be_kind_of Account }
+    end
+
+    describe '.to_adapter.get!' do
+      let(:user) { FactoryGirl.create(:user) }
+      subject { Account.to_adapter.get!(user.to_key) }
+      its(:user) { should == user }
+      it { should be_kind_of Account }
+    end
+
+  end
+
+  describe '#update_with_password' do
+    let(:password) { 'a password' }
+    let(:user) { subject.user }
+    let(:person) { user.person }
+    let(:alternate_email) { 'somewhere@not-here.com'}
+    subject { FactoryGirl.create(:account) }
+    describe 'with valid attributes' do
+      it 'should update the user' do
+        expect {
+          expect {
+            subject.update_with_password(current_password: password, alternate_email: alternate_email)
+          }.to change(user, :alternate_email).to(alternate_email)
+        }.to change(person, :alternate_email).to(alternate_email)
+      end
+
+    end
+
+    describe 'with invalid attributes' do
+      it 'should update the user' do
+        expect {
+          expect {
+            subject.update_with_password(current_password: password*2, alternate_email: alternate_email)
+          }.to_not change(user, :alternate_email)
+        }.to_not change(person, :alternate_email)
+
+        expect(subject.errors).to_not be_empty
+      end
+    end
+  end
+
+  describe '#save via .new_with_session' do
+    let(:expected_name) { 'Robert Frost' }
+    let(:attributes) { FactoryGirl.attributes_for(:user, name: expected_name) }
+    let(:session) { {} }
+
+    subject { Account.new_with_session(attributes, session) }
+    describe 'valid attributes' do
+      it 'should create a user, person, and profile' do
+        expect {
+          expect {
+            expect {
+              subject.save
+            }.to change(User, :count).by(1)
+          }.to change(Person, :count).by(1)
+        }.to change(Collection, :count).by(1)
+
+        user = subject.user.reload
+        expect(user.name).to eq(expected_name)
+        expect(user.person).to be_persisted
+        expect(user.person).to eq(subject.person)
+
+        expect(subject.person.read_groups).to include(Sufia::Models::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
+        expect(subject.person.edit_users).to include(user.user_key)
+        expect(subject.person.depositor).to eq user.user_key
+        expect(subject.person.name).to eq expected_name
+
+        expect(subject.profile.read_groups).to include(Sufia::Models::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
+        expect(subject.profile.edit_users).to include(user.user_key)
+        expect(subject.profile.depositor).to eq user.user_key
+        expect(subject.profile.title).to eq expected_name
+      end
+    end
+
+    describe 'invalid attributes' do
+      let(:attributes) { FactoryGirl.attributes_for(:user).merge(password: 'a valid password', password_confirmation: 'an invalid password') }
+      let(:session) { {} }
+
+      subject { Account.new_with_session(attributes, session) }
+
+      it 'should not create a user even if the user is valid but the person is not' do
+        expect {
+          expect {
+            expect {
+              subject.save
+            }.to_not change(User, :count)
+          }.to_not change(Person, :count)
+        }.to_not change(Collection, :count)
+        expect(subject.errors).to_not be_empty
+      end
+    end
+  end
+
+  describe 'factories', factory_verification: true do
+    describe '.build' do
+      it 'should not persist' do
+        account = FactoryGirl.build(:account)
+        expect(account.user).to_not be_persisted
+        expect(account.person).to_not be_persisted
+        expect(account.profile).to_not be_persisted
+      end
+    end
+
+    describe '.create' do
+      it 'should persist' do
+        account = FactoryGirl.create(:account)
+        user = User.find(account.user.id)
+        expect(account.user).to eq user
+        expect(account.person).to eq user.person
+        expect(account.profile).to eq user.person.profile
+      end
+    end
+  end
+end

--- a/spec/models/curate/user_spec.rb
+++ b/spec/models/curate/user_spec.rb
@@ -2,13 +2,4 @@ require 'spec_helper'
 
 describe Curate::User do
 
-  it 'should create a person when a user is created' do
-    new_user = FactoryGirl.build(:user, email: "test.user@example.com")
-    new_user.save!
-    new_user.person.class.should == Person
-    new_user.person.read_groups.should include(Sufia::Models::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
-    new_user.person.edit_users.should include(new_user.user_key)
-    new_user.person.depositor.should == new_user.user_key
-  end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,19 +11,9 @@ require File.expand_path("../internal/config/environment.rb",  __FILE__)
 
 require File.expand_path('../spec_patch', __FILE__)
 require 'curate/spec_support'
+require 'database_cleaner'
 
-# This is hear because it cannot be part of spec_support as other
-# Curate based apps would very likely register a :user
-FactoryGirl.define do
-  factory :user do
-    sequence(:email) {|n| "email-#{srand}@test.com" }
-    agreed_to_terms_of_service true
-    user_does_not_require_profile_update true
-    password 'a password'
-    password_confirmation 'a password'
-    sign_in_count 20
-  end
-end
+require 'curate/internal/factories'
 
 Rails.backtrace_cleaner.remove_silencers!
 
@@ -37,7 +27,6 @@ RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.fixture_path = File.expand_path("../fixtures", __FILE__)
-  
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
@@ -50,6 +39,20 @@ RSpec.configure do |config|
     file_path: config.escaped_path(%w[spec inputs])
   }
 
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
+
+  config.before(:suite) do
+    ActiveFedora::Base.destroy_all
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 
 end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -3,6 +3,31 @@ require File.expand_path('../features/javascript', __FILE__)
 require File.expand_path('../features/create_works', __FILE__)
 require File.expand_path('../curate_fixture_file_upload', __FILE__)
 
+require 'capybara/poltergeist'
+
+Capybara.register_driver :poltergeist_debug do |app|
+  Capybara::Poltergeist::Driver.new(app, :inspector => true)
+end
+
+module FeatureSupport
+  module_function
+  def options(default = {type: :feature})
+    if ENV['JS']
+      Capybara.javascript_driver = default.fetch(:javascript_driver, :poltergeist_debug)
+      default[:js] = true
+    else
+      Capybara.javascript_driver = default.fetch(:javascript_driver, :poltergeist)
+    end
+
+    if ENV['LOCAL']
+      Capybara.current_driver = default.fetch(:javascript_driver, :poltergeist_debug)
+    end
+    default
+  end
+end
+
+
+
 RSpec.configure do |config|
   config.include CurateFixtureFileUpload
   config.include Devise::TestHelpers, type: :controller

--- a/tasks/curate_tasks.rake
+++ b/tasks/curate_tasks.rake
@@ -46,7 +46,9 @@ gem 'selenium-webdriver'
 gem 'factory_girl_rails'
 gem 'timecop'
 gem 'rspec-html-matchers'
-gem 'test_after_commit', :group => :test
+gem 'database_cleaner', '< 1.1.0', :group => :test
+gem 'test_after_commit', group: :test
+gem 'poltergeist', group: :test
 gem 'kaminari', github: 'harai/kaminari', branch: 'route_prefix_prototype'" >> #{DUMMY_APP}/Gemfile`
 
     puts "Copying generator"


### PR DESCRIPTION
Achtung!

Our User#create and User#update actions were getting complicated; This
complication impacted our tests, rapidly increasing run times. It also
incorporated several callbacks, which can quickly spiral into
something very labrynthine.

However, due to some of the constraints and design decisions of the
Devise and ActiveRecord, using the Account composite object in
Devise's registration controller creates complicating code.

I have worked hard to isolate this complicated negotiation of Devise,
ActiveRecord, and ActiveFedora inside the Account class.

So, this commit is here to balance three things:
- Callbacks being implicitly called for behavior vs.
  Explicitly declared behavior (i.e. an Account represents a User,
  Person, and Profile).
- Improving test speeds via "better" production code factoring vs.
  improving speeds via test trickery.
- Creating understandable and maintainable code; This one is likely
  the most contentious as the Account composite object is non-trivial
  and dependendent on the Devise implementation.

Incidentally, this is highlighting how we might be able to model an
object that is persisted in Fedora and ActiveRecord.

Closes ndlib/planning#180
