### PR TITLE
Show stub metdata for private repository objects.

### DIFF
--- a/app/controllers/curation_concern/base_controller.rb
+++ b/app/controllers/curation_concern/base_controller.rb
@@ -27,7 +27,16 @@ module CurationConcern
     self.excluded_actions_for_curation_concern_authorization = [:new, :create]
     before_filter :authorize_curation_concern!, except: excluded_actions_for_curation_concern_authorization
     def authorize_curation_concern!
-      authorize!(action_name_for_authorization, curation_concern) || true
+      if action_name_for_authorization == :show
+        if can?(:show, curation_concern)
+          return true
+        else
+          render 'unauthorized', status: :unauthorized
+          false
+        end
+      else
+        authorize!(action_name_for_authorization, curation_concern) || true
+      end
     end
 
     def action_name_for_authorization

--- a/app/views/curate/collections/unauthorized.html.erb
+++ b/app/views/curate/collections/unauthorized.html.erb
@@ -1,0 +1,3 @@
+<h1>Unauthorized</h1>
+<p>The collection you have tried to access is private<p>
+<p>ID: <%= @collection.id %>

--- a/app/views/curation_concern/base/unauthorized.html.erb
+++ b/app/views/curation_concern/base/unauthorized.html.erb
@@ -1,0 +1,3 @@
+<h1>Unauthorized</h1>
+<p>The <%= curation_concern.human_readable_type.downcase %> you have tried to access is private<p>
+<p>ID: <%= curation_concern.id %>

--- a/spec/controllers/curation_concern/articles_controller_spec.rb
+++ b/spec/controllers/curation_concern/articles_controller_spec.rb
@@ -17,6 +17,7 @@ describe CurationConcern::ArticlesController do
       it "should show 401 Unauthorized" do
         get :show, id: article
         expect(response.status).to eq 401
+        response.should render_template(:unauthorized)
       end
     end
     context "someone elses public work" do

--- a/spec/controllers/curation_concern/etds_controller_spec.rb
+++ b/spec/controllers/curation_concern/etds_controller_spec.rb
@@ -17,6 +17,7 @@ describe CurationConcern::EtdsController do
       it "should show 401 Unauthorized" do
         get :show, id: etd
         expect(response.status).to eq 401
+        response.should render_template(:unauthorized)
       end
     end
     context "someone elses public work" do

--- a/spec/controllers/curation_concern/generic_files_controller_spec.rb
+++ b/spec/controllers/curation_concern/generic_files_controller_spec.rb
@@ -185,9 +185,9 @@ describe CurationConcern::GenericFilesController do
     it 'does not allow another user to view it' do
       generic_file
       sign_in another_user
-      expect {
-        get :show, id: generic_file.to_param
-      }.to raise_rescue_response_type(:unauthorized)
+      get :show, id: generic_file.to_param
+      expect(response.status).to eq 401
+      response.should render_template(:unauthorized)
     end
   end
 

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -7,14 +7,15 @@ FactoryGirl.define do
     before(:create) { |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
     }
+
+    factory :public_collection do
+      visibility Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    factory :private_collection do
+      visibility Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
   end
 
-  factory :public_collection, class: :collection do
-    sequence(:title) {|n| "Title #{n}"}
-    before(:create) { |work, evaluator|
-      work.apply_depositor_metadata(FactoryGirl.create(:user).user_key)
-      work.read_groups = ['public']
-    }
-  end
 end
 

--- a/spec/factories/generic_files_factory.rb
+++ b/spec/factories/generic_files_factory.rb
@@ -9,6 +9,10 @@ FactoryGirl.define do
     before(:create) { |file, evaluator|
        file.apply_depositor_metadata(evaluator.user.user_key)
     }
+
+    factory :private_generic_file do
+      visibility Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
   end
 end
 

--- a/spec/features/article_spec.rb
+++ b/spec/features/article_spec.rb
@@ -54,3 +54,17 @@ describe 'An existing article' do
   end
 end
 
+describe 'Viewing an Article that is private' do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:work) { FactoryGirl.create(:private_article, title: "Sample work" ) }
+
+  it 'should show a stub indicating we have the work, but it is private' do
+    login_as(user)
+    visit curation_concern_article_path(work)
+    page.should have_content('Unauthorized')
+    page.should have_content('The article you have tried to access is private')
+    page.should have_content("ID: #{work.pid}")
+    page.should_not have_content("Sample work")
+  end
+end
+

--- a/spec/features/collections_spec.rb
+++ b/spec/features/collections_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Collections" do
+describe "Showing and creating Collections" do
   let(:user) { FactoryGirl.create(:user) }
 
   it "should create them" do
@@ -30,3 +30,18 @@ describe "Collections" do
     expect(page).to have_button('Create Collection')
   end
 end
+
+describe 'Viewing a collection that is private' do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:collection) { FactoryGirl.create(:private_collection, title: "Sample collection" ) }
+
+  it 'should show a stub indicating we have the work, but it is private' do
+    login_as(user)
+    visit collection_path(collection)
+    page.should have_content('Unauthorized')
+    page.should have_content('The collection you have tried to access is private')
+    page.should have_content("ID: #{collection.pid}")
+    page.should_not have_content("Sample collection")
+  end
+end
+

--- a/spec/features/dataset_spec.rb
+++ b/spec/features/dataset_spec.rb
@@ -53,3 +53,18 @@ describe 'An existing dataset' do
   end
 end
 
+describe 'Viewing a Dataset that is private' do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:work) { FactoryGirl.create(:private_dataset, title: "Sample work" ) }
+
+  it 'should show a stub indicating we have the work, but it is private' do
+    login_as(user)
+    visit curation_concern_dataset_path(work)
+    page.should have_content('Unauthorized')
+    page.should have_content('The dataset you have tried to access is private')
+    page.should have_content("ID: #{work.pid}")
+    page.should_not have_content("Sample work")
+  end
+end
+
+

--- a/spec/features/error_handlers_spec.rb
+++ b/spec/features/error_handlers_spec.rb
@@ -22,14 +22,10 @@ describe 'error behavior', describe_options do
 
   let(:curation_concern_type) { :generic_work }
   let(:user) { FactoryGirl.create(:user) }
-  let(:visibility) { Sufia::Models::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
-  let(:curation_concern) {
-    FactoryGirl.create_curation_concern(
-      curation_concern_type, user, {visibility: visibility}
-    )
-  }
+  let(:curation_concern) { FactoryGirl.create(:private_generic_work) }
   it 'handles unauthorized pages'do
-    visit("/concern/#{curation_concern_type.to_s.pluralize}/#{curation_concern.to_param}")
+    login_as user
+    visit edit_curation_concern_generic_work_path(curation_concern)
     expect(page).to have_content("Unauthorized")
     expect(page).to have_content("You are not authorized to access the page.")
   end

--- a/spec/features/etd_spec.rb
+++ b/spec/features/etd_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'Viewing an ETD that is private' do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:work) { FactoryGirl.create(:private_etd, title: "Sample work" ) }
+
+  it 'should show a stub indicating we have the work, but it is private' do
+    login_as(user)
+    visit curation_concern_etd_path(work)
+    page.should have_content('Unauthorized')
+    page.should have_content('The etd you have tried to access is private')
+    page.should have_content("ID: #{work.pid}")
+    page.should_not have_content("Sample work")
+  end
+end
+
+
+

--- a/spec/features/generic_file_spec.rb
+++ b/spec/features/generic_file_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Generic File' do
+describe 'Uploading Generic File' do
   let(:user) { FactoryGirl.create(:user) }
   let(:another_user) { FactoryGirl.create(:user) }
 
@@ -54,5 +54,19 @@ describe 'Generic File' do
       click_on("Attach to Generic Work")
     end
   end
-
 end
+
+describe 'Viewing a generic file that is private' do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:work) { FactoryGirl.create(:private_generic_file, title: "Sample file" ) }
+
+  it 'should show a stub indicating we have the work, but it is private' do
+    login_as(user)
+    visit curation_concern_generic_file_path(work)
+    page.should have_content('Unauthorized')
+    page.should have_content('The generic file you have tried to access is private')
+    page.should have_content("ID: #{work.pid}")
+    page.should_not have_content("Sample file")
+  end
+end
+

--- a/spec/features/generic_work_spec.rb
+++ b/spec/features/generic_work_spec.rb
@@ -26,7 +26,7 @@ describe 'Creating a generic work' do
   end
 end
 
-describe 'An existing generic work' do
+describe 'An existing generic work owned by the user' do
   let(:user) { FactoryGirl.create(:user) }
   let(:work) { FactoryGirl.create(:generic_work, user: user) }
   let(:you_tube_link) { 'http://www.youtube.com/watch?v=oHg5SJYRHA0' }
@@ -64,4 +64,19 @@ describe 'An existing generic work' do
     end
   end
 end
+
+describe 'Viewing a generic work that is private' do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:work) { FactoryGirl.create(:private_generic_work, title: "Sample work" ) }
+
+  it 'should show a stub indicating we have the work, but it is private' do
+    login_as(user)
+    visit curation_concern_generic_work_path(work)
+    page.should have_content('Unauthorized')
+    page.should have_content('The generic work you have tried to access is private')
+    page.should have_content("ID: #{work.pid}")
+    page.should_not have_content("Sample work")
+  end
+end
+
 

--- a/spec/support/shared/shared_examples_is_a_curation_concern_actor.rb
+++ b/spec/support/shared/shared_examples_is_a_curation_concern_actor.rb
@@ -17,7 +17,6 @@ shared_examples 'is_a_curation_concern_actor' do |curation_concern_class|
 
       describe 'with a file' do
         let(:attributes) {
-          puts "FACtory #{default_work_factory_name}"
           FactoryGirl.attributes_for(default_work_factory_name, visibility: visibility).tap {|a|
             a[:files] = file
           }

--- a/spec/support/shared/shared_examples_is_a_curation_concern_controller.rb
+++ b/spec/support/shared/shared_examples_is_a_curation_concern_controller.rb
@@ -30,6 +30,7 @@ shared_examples 'is_a_curation_concern_controller' do |curation_concern_class, a
         it "should show 401 Unauthorized" do
           get :show, id: a_work
           expect(response.status).to eq 401
+          response.should render_template(:unauthorized)
         end
       end
       context "someone elses public work" do


### PR DESCRIPTION
When collectable things ( i.e Content, Works, and Collections ) are not
viewable by a User their existence will be acknowledged but only in an
anonymized form.

Fixes ndlib/planning#105
