### PR TITLE
Fix spelling of license. Move legalese into a partial.

### DIFF
--- a/app/models/contributor_agreement.rb
+++ b/app/models/contributor_agreement.rb
@@ -6,43 +6,6 @@ class ContributorAgreement
     @param_value = params[param_key.to_sym] || params[param_key.to_s]
   end
 
-  def legally_binding_text
-    <<-HTML
-    <p>
-      I am submitting my work for inclusion in the #{I18n.t('sufia.product_name')} repository maintained by the University Libraries of the #{ I18n.t('sufia.institution_name') }.
-      I acknowledge that publication of the work may implicate my legal rights with respect to the work and its contents, including my ability to publish the work in other venues.
-      I UNDERSTAND AND AGREE THAT BY SUBMITTING MY CONTENT FOR INCLUSION IN THE #{I18n.t('sufia.product_name').upcase} REPOSITORY, I AGREE TO THE FOLLOWING TERMS:
-    </p>
-
-    <p>
-      I hereby grant the #{ I18n.t('sufia.institution_name') } permission to reproduce, edit, publish, disseminate, publicly display, or publicly perform, in whole or in part, the work in any medium at the University&rsquo;s discretion (including but not limited to public websites).
-      I agree that the University can keep more than one copy of the submission for the purpose of preservation and security.
-      I agree that the University can preserve the submission by migrating or translating it to a new format or medium as needed in the future.
-      I also agree that the metadata attached to the item can be reviewed and altered by the University to aid in preservation and discovery.
-      I understand that I may be allowed the opportunity to select the intended audience for the materials that I submit, and I agree that I am fully responsible for any claims and all responsibility for materials submitted.
-      The #{I18n.t('sufia.product_name')} service is offered as-is with no warranties, express or implied.
-      The University may suspend or terminate #{I18n.t('sufia.product_name')}, or remove any content within the system, at any time for any reason in the University&rsquo;s sole discretion.
-    </p>
-
-    <p>
-      I warrant that the submitted material is original to me and that I have power to make this agreement.
-      I also warrant that the submission does not, to the best of my knowledge, infringe upon anyone&rsquo;s copyright.
-      I also warrant that if the work has been previously published elsewhere in whole or in part, that I have obtained the permission of the copyright owner to grant #{I18n.t('sufia.product_name')} the rights required by this license.
-      I also guarantee that I do not have any other publication agreements that involve this material or substantial parts of it that conflict with my submission of materials for dissemination in #{I18n.t('sufia.product_name')}.
-    </p>
-
-    <p>
-      I represent that any materials that are used in this submission that I do not hold copyright for, I have obtained permission to use and display the materials according to the rights required by this license, and that third-party owned materials are clearly identified and credited within the content of the submission.
-      If it is determined that permissions of use have not properly been obtained, I acknowledge that the University may remove or restrict access to items as necessary.
-    </p>
-
-    <p>
-      I understand that I may request the University to remove my submitted materials from the #{I18n.t('sufia.product_name')} repository; however, I acknowledge that the University cannot control or retract works that may have been accessed by third parties prior to my request for removal.
-      If the submission is removed I agree that the item can be replaced by a page with a statement declaring that the item was removed by my request.
-    </p>
-    HTML
-  end
-
   def acceptance_value
     'accept'
   end

--- a/app/views/curation_concern/base/_form_content_license.html.erb
+++ b/app/views/curation_concern/base/_form_content_license.html.erb
@@ -4,7 +4,7 @@
     What do you want others to be able to do with your work?
   </p>
   <p>
-    <a href="http://creativecommons.org/licenses/" target="_blank">Here's some help</a> if you don't know which licence to choose.
+    <a href="http://creativecommons.org/licenses/" target="_blank">Here's some help</a> if you don't know which license to choose.
   </p>
 
   <%= f.input :rights,

--- a/app/views/curation_concern/base/_form_contributor_agreement.html.erb
+++ b/app/views/curation_concern/base/_form_contributor_agreement.html.erb
@@ -8,7 +8,7 @@
 
     <div class="span12">
       <article class="lawyer_readable contributor_agreement wide-text">
-        <%= contributor_agreement.legally_binding_text.html_safe %>
+        <%= render partial: 'legally_binding_text' %>
       </article>
     </div>
 
@@ -21,7 +21,7 @@
             required: :required
           )
         %>
-        I have read and accept the contributor licence agreement
+        I have read and accept the contributor license agreement
       <% end %>
     </div>
   </fieldset>

--- a/app/views/curation_concern/base/_legally_binding_text.html.erb
+++ b/app/views/curation_concern/base/_legally_binding_text.html.erb
@@ -1,0 +1,33 @@
+    <p>
+      I am submitting my work for inclusion in the <%=I18n.t('sufia.product_name')%> repository maintained by the University Libraries of the <%= I18n.t('sufia.institution_name') %>.
+      I acknowledge that publication of the work may implicate my legal rights with respect to the work and its contents, including my ability to publish the work in other venues.
+      I UNDERSTAND AND AGREE THAT BY SUBMITTING MY CONTENT FOR INCLUSION IN THE <%=I18n.t('sufia.product_name').upcase%> REPOSITORY, I AGREE TO THE FOLLOWING TERMS:
+    </p>
+
+    <p>
+      I hereby grant the <%= I18n.t('sufia.institution_name') %> permission to reproduce, edit, publish, disseminate, publicly display, or publicly perform, in whole or in part, the work in any medium at the University&rsquo;s discretion (including but not limited to public websites).
+      I agree that the University can keep more than one copy of the submission for the purpose of preservation and security.
+      I agree that the University can preserve the submission by migrating or translating it to a new format or medium as needed in the future.
+      I also agree that the metadata attached to the item can be reviewed and altered by the University to aid in preservation and discovery.
+      I understand that I may be allowed the opportunity to select the intended audience for the materials that I submit, and I agree that I am fully responsible for any claims and all responsibility for materials submitted.
+      The <%=I18n.t('sufia.product_name')%> service is offered as-is with no warranties, express or implied.
+      The University may suspend or terminate <%=I18n.t('sufia.product_name')%>, or remove any content within the system, at any time for any reason in the University&rsquo;s sole discretion.
+    </p>
+
+    <p>
+      I warrant that the submitted material is original to me and that I have power to make this agreement.
+      I also warrant that the submission does not, to the best of my knowledge, infringe upon anyone&rsquo;s copyright.
+      I also warrant that if the work has been previously published elsewhere in whole or in part, that I have obtained the permission of the copyright owner to grant <%=I18n.t('sufia.product_name')%> the rights required by this license.
+      I also guarantee that I do not have any other publication agreements that involve this material or substantial parts of it that conflict with my submission of materials for dissemination in <%=I18n.t('sufia.product_name')%>.
+    </p>
+
+    <p>
+      I represent that any materials that are used in this submission that I do not hold copyright for, I have obtained permission to use and display the materials according to the rights required by this license, and that third-party owned materials are clearly identified and credited within the content of the submission.
+      If it is determined that permissions of use have not properly been obtained, I acknowledge that the University may remove or restrict access to items as necessary.
+    </p>
+
+    <p>
+      I understand that I may request the University to remove my submitted materials from the <%=I18n.t('sufia.product_name')%> repository; however, I acknowledge that the University cannot control or retract works that may have been accessed by third parties prior to my request for removal.
+      If the submission is removed I agree that the item can be replaced by a page with a statement declaring that the item was removed by my request.
+    </p>
+

--- a/app/views/curation_concern/form/_content_license.html.erb
+++ b/app/views/curation_concern/form/_content_license.html.erb
@@ -4,7 +4,7 @@
     What do you want others to be able to do with your work?
   </p>
   <p>
-    <a href="http://creativecommons.org/licenses/" target="_blank">Here's some help</a> if you don't know which licence to choose.
+    <a href="http://creativecommons.org/licenses/" target="_blank">Here's some help</a> if you don't know which license to choose.
   </p>
 
   <%= f.input :rights,

--- a/spec/features/article_spec.rb
+++ b/spec/features/article_spec.rb
@@ -15,7 +15,7 @@ describe 'Creating a article' do
         fill_in "Abstract", with: "My abstract"
         fill_in "External link", with: "http://www.youtube.com/watch?v=oHg5SJYRHA0"
         select(Sufia.config.cc_licenses.keys.first, from: I18n.translate('sufia.field_label.rights'))
-        check("I have read and accept the contributor licence agreement")
+        check("I have read and accept the contributor license agreement")
         click_button("Create Article")
       end
       expect(page).to have_selector('h1', text: 'Article')

--- a/spec/features/dataset_spec.rb
+++ b/spec/features/dataset_spec.rb
@@ -14,7 +14,7 @@ describe 'Creating a dataset' do
         fill_in "Title", with: "My title"
         fill_in "External link", with: "http://www.youtube.com/watch?v=oHg5SJYRHA0"
         select(Sufia.config.cc_licenses.keys.first, from: I18n.translate('sufia.field_label.rights'))
-        check("I have read and accept the contributor licence agreement")
+        check("I have read and accept the contributor license agreement")
         click_button("Create Dataset")
       end
       expect(page).to have_selector('h1', text: 'Dataset')

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -239,7 +239,7 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
       fill_out_form_multi_value_for('contributor', with: options['Contributors'])
 
       if options['I Agree']
-        check("I have read and accept the contributor licence agreement")
+        check("I have read and accept the contributor license agreement")
       end
       click_on(options["Button to click"])
     end

--- a/spec/features/generic_work_spec.rb
+++ b/spec/features/generic_work_spec.rb
@@ -14,7 +14,7 @@ describe 'Creating a generic work' do
         fill_in "Title", with: "My title"
         fill_in "External link", with: "http://www.youtube.com/watch?v=oHg5SJYRHA0"
         select(Sufia.config.cc_licenses.keys.first, from: I18n.translate('sufia.field_label.rights'))
-        check("I have read and accept the contributor licence agreement")
+        check("I have read and accept the contributor license agreement")
         click_button("Create Generic work")
       end
       

--- a/spec/models/contributor_agreement_spec.rb
+++ b/spec/models/contributor_agreement_spec.rb
@@ -7,10 +7,6 @@ describe ContributorAgreement do
   let(:params) { {} }
 
 
-  it 'has legally binding text' do
-    subject.legally_binding_text.should be_kind_of(String)
-  end
-
   it 'has acceptance value' do
     subject.acceptance_value.should == 'accept'
   end


### PR DESCRIPTION
This allows each institution to have their own licence by simply
overriding the partial
`app/views/curation_concern/base/_legally_binding_text.html.erb`

Fixes ndlib/planning#252
It is also a partial fix for ndlib/planning#230
