### PR TITLE
Adding Configurable DOI Support

### DIFF
--- a/app/views/curation_concern/base/_form_doi.html.erb
+++ b/app/views/curation_concern/base/_form_doi.html.erb
@@ -1,0 +1,44 @@
+<%- if curation_concern.identifier.present? -%>
+  <%# Please forgive this questionably semantic markup -- it should just _look_ the same as a legend/fieldset %>
+  <fieldset>
+    <legend>Digital Object Identifier</legend>
+    <p>
+      This
+      <%= classify_for_display(curation_concern) %>
+      has a <abbr title="Digital Object Identifier">DOI</abbr>.
+    </p>
+    <p>
+      <strong><%= link_to curation_concern.identifier, remote_service.remote_uri_for(curation_concern.identifier) %></strong>
+    </p>
+    <p>
+      This <abbr title="Digital Object Identifier" data-placement="right">DOI</abbr> link is the best way for others to cite your work.
+    </p>
+  </fieldset>
+<%- else -%>
+  <fieldset class="promote promote-doi">
+    <legend>
+      Assign a Digital Object Identifier (DOI)
+    </legend>
+
+    <p>
+      A <abbr title="Digital Object Identifier" data-placement="right">DOI</abbr> is a permanent link to your
+      <%= classify_for_display(curation_concern) %>.
+      It&rsquo;s an easy way for other people to cite your work.
+    </p>
+    <p>
+      Want more information on <abbr title="Digital Object Identifier">DOI</abbr>s?
+      Here&rsquo;s a <a href="http://simple.wikipedia.org/wiki/Doi" target="_blank">brief summary</a> and the <a href="http://www.doi.org/faq.html" target="_blank">DOI FAQ</a>.
+    </p>
+
+    <div class="control-group">
+      <%= f.label remote_service.accessor_name, class: 'label label-success label-large label-checkbox' do %>
+        <%= f.check_box remote_service.accessor_name %>
+        <span class="label-text">
+          Yes, I would like to assign this
+          <%= classify_for_display(curation_concern) %>
+          a <abbr title="Digital Object Identifier">DOI</abbr>.
+        </span>
+      <% end %>
+    </div>
+  </fieldset>
+<%- end -%>

--- a/app/views/curation_concern/base/_form_supplementary_fields.html.erb
+++ b/app/views/curation_concern/base/_form_supplementary_fields.html.erb
@@ -28,6 +28,14 @@
   </fieldset>
 <% end %>
 
+<%- Hydra::RemoteIdentifier.with_registered_remote_service(:doi, curation_concern) do |remote_service| -%>
+  <div class="row with-headroom">
+    <div class="span6">
+      <%= render "form_doi", curation_concern: curation_concern, f: f, remote_service: remote_service %>
+    </div>
+  </div>
+<%- end -%>
+
 <div class="row with-headroom">
   <div class="span12">
     <%= render "form_permission", curation_concern: curation_concern, f: f %>

--- a/app/workers/mint_remote_identifier_worker.rb
+++ b/app/workers/mint_remote_identifier_worker.rb
@@ -1,0 +1,25 @@
+class MintRemoteIdentifierWorker
+  def self.enqueue(pid, remote_service_name)
+    Sufia.queue.push(new(pid, remote_service_name))
+  end
+
+  def queue_name
+    :remote_identifiers
+  end
+
+  attr_reader :pid, :remote_service_name
+  def initialize(pid, remote_service_name)
+    @pid = pid
+    @remote_service_name = remote_service_name
+  end
+
+  def run
+    Hydra::RemoteIdentifier.mint(remote_service_name, target)
+  end
+
+  private
+  def target
+    @target ||= ActiveFedora::Base.find(pid)
+  end
+
+end

--- a/curate.gemspec
+++ b/curate.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'browser'
   s.add_dependency 'breadcrumbs_on_rails'
   s.add_dependency 'active_fedora-registered_attributes', '~> 0.1.0'
+  s.add_dependency 'hydra-remote_identifier', '~> 0.5'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "factory_girl_rails"

--- a/lib/curate.rb
+++ b/lib/curate.rb
@@ -5,6 +5,7 @@ require 'simple_form'
 require 'bootstrap-datepicker-rails'
 require 'hydra-batch-edit'
 require 'active_fedora/registered_attributes'
+require 'hydra/remote_identifier'
 
 module Curate
   extend ActiveSupport::Autoload

--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -8,6 +8,7 @@ class CurateGenerator < Rails::Generators::Base
 
   source_root File.expand_path('../templates', __FILE__)
 
+  class_option :with_doi, default: false, type: :boolean
 
   desc """
 This generator makes the following changes to your application:
@@ -38,6 +39,7 @@ This generator makes the following changes to your application:
     remove_dir('app/views/devise')
     generate "hydra:head -f"
     generate "sufia:models:install#{options[:force] ? ' -f' : ''}"
+    generate "hydra:remote_identifier:install#{options[:force] ? ' -f' : ''}"
   end
 
   # Add behaviors to the application controller
@@ -92,6 +94,12 @@ This generator makes the following changes to your application:
       data << "end"
 
       data.join("\n")
+    end
+  end
+
+  def register_remote_identifiers
+    if options.fetch('with_doi', false)
+      generate 'curate:work:with_doi', DEFAULT_CURATION_CONCERNS.collect(&:to_s).join(" ")
     end
   end
 

--- a/lib/generators/curate/work/templates/README
+++ b/lib/generators/curate/work/templates/README
@@ -6,7 +6,7 @@ After creating your work you may wish to:
 
       Your newly created work's controller extends from
       CurationConcern::GenericWorksController; This means that it will use the
-      views of found in Curate::Engine.root/app/views/curation_concern/generic_works.
+      views found in Curate::Engine.root/app/views/curation_concern/generic_works.
 
   2. Modify the model and datastreams
 

--- a/lib/generators/curate/work/templates/controller_spec.rb.erb
+++ b/lib/generators/curate/work/templates/controller_spec.rb.erb
@@ -3,5 +3,5 @@
 require 'spec_helper'
 
 describe CurationConcern::<%= class_name.pluralize %>Controller do
-  include_examples 'is_a_curation_concern_controller', <%= class_name %>, :all
+  include_examples 'is_a_curation_concern_controller', <%= class_name %>, actions: :all
 end

--- a/lib/generators/curate/work/templates/model.rb.erb
+++ b/lib/generators/curate/work/templates/model.rb.erb
@@ -6,6 +6,7 @@ class <%= class_name %> < ActiveFedora::Base
   include CurationConcern::Model
   include CurationConcern::WithGenericFiles
   include CurationConcern::WithLinkedResources
+  include CurationConcern::WithRelatedWorks
   include CurationConcern::Embargoable
   include ActiveFedora::RegisteredAttributes
 

--- a/lib/generators/curate/work/templates/model_spec.rb.erb
+++ b/lib/generators/curate/work/templates/model_spec.rb.erb
@@ -11,5 +11,8 @@ describe <%= class_name %> do
   it_behaves_like 'with_access_rights'
   it_behaves_like 'is_embargoable'
   it_behaves_like 'has_dc_metadata'
+  <%- if register_doi? -%>
+  it_behaves_like 'remotely_identified', :doi
+  <%- end -%>
 
 end

--- a/lib/generators/curate/work/with_doi/with_doi_generator.rb
+++ b/lib/generators/curate/work/with_doi/with_doi_generator.rb
@@ -1,0 +1,26 @@
+# -*- encoding : utf-8 -*-
+require 'rails/generators'
+
+module Curate::Work
+  class WithDoiGenerator <  Rails::Generators::Base
+    argument :targets, type: :array, required: true, banner: "target, target"
+    def append_doi_initializer
+      options = targets
+      options << [%(--target='{|o| "http://localhost/concern/\#{o.class.model_name}/\#{o.to_param}" }')]
+      options << [%(--creator=:creator)]
+      options << [%(--title=:title)]
+      options << [%(--publisher='{|o| Array(o.publisher).join("; ")}')]
+      options << [%(--publication_year='{|o| o.date_uploaded.year }')]
+      options << [%(--set_identifier='{|o,value| o.identifier = value; o.save }')]
+      args = ['hydra:remote_identifier:doi', options.join(" ")]
+
+      if behavior == :revoke
+        destroy(*args)
+      else
+        generate(*args)
+      end
+
+    end
+
+  end
+end

--- a/spec/controllers/curation_concern/datasets_controller_spec.rb
+++ b/spec/controllers/curation_concern/datasets_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe CurationConcern::DatasetsController do
-  include_examples 'is_a_curation_concern_controller', Dataset, :all
+  include_examples 'is_a_curation_concern_controller', Dataset, actions: :all
 end

--- a/spec/controllers/curation_concern/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concern/generic_works_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe CurationConcern::GenericWorksController do
-  include_examples 'is_a_curation_concern_controller', GenericWork, :all
+  include_examples 'is_a_curation_concern_controller', GenericWork, actions: :all
 end

--- a/spec/services/curation_concern/base_actor_spec.rb
+++ b/spec/services/curation_concern/base_actor_spec.rb
@@ -26,6 +26,7 @@ describe CurationConcern::BaseActor do
 
     describe 'success' do
       it 'returns true' do
+        subject.stub(:assign_remote_identifier_if_applicable).and_return(true)
         subject.create.should be_true
       end
     end

--- a/spec/skeleton/lib/generators/test_app_generator.rb
+++ b/spec/skeleton/lib/generators/test_app_generator.rb
@@ -6,7 +6,7 @@ class TestAppGenerator < Rails::Generators::Base
   def run_curate_generator
     say_status("warning", "GENERATING CURATE", :yellow)
 
-    generate 'curate', '-f'
+    generate 'curate', '-f --with-doi'
 
     gsub_file('config/environments/test.rb', /^.*config\.consider_all_requests_local.*$/) do |match|
       match = "  # For end to end specs, I want the exception handler capturing things; Not raising exceptions.\n  config.consider_all_requests_local = ENV['LOCAL'] || false"

--- a/spec/support/shared/shared_examples_remotely_identified.rb
+++ b/spec/support/shared/shared_examples_remotely_identified.rb
@@ -1,0 +1,13 @@
+shared_examples 'remotely_identified' do |remote_service_name|
+  context "by #{remote_service_name}" do
+    subject { FactoryGirl.create(described_class.name.underscore, publisher: 'An Interesting Chap!') }
+    it 'mints!' do
+      expect {
+        Hydra::RemoteIdentifier.mint(remote_service_name, subject)
+      }.to change(subject, :identifier).from(nil)
+    end
+    after(:each) {
+      subject.destroy
+    }
+  end
+end

--- a/spec/workers/mint_remote_identifier_worker_spec.rb
+++ b/spec/workers/mint_remote_identifier_worker_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe MintRemoteIdentifierWorker do
+  let(:pid) { 'abc' }
+  let(:target) { double }
+  let(:remote_service_name) { :doi }
+  let(:minter) {
+    lambda { |name, target|
+      target.remote_service_name = name
+    }
+  }
+  before(:each) do
+    ActiveFedora::Base.should_receive(:find).with(pid).and_return(target)
+    Hydra::RemoteIdentifier.should_receive(:mint).with(remote_service_name, target)
+  end
+
+  subject { MintRemoteIdentifierWorker.new(pid, remote_service_name) }
+
+  specify {
+    subject.run
+  }
+end


### PR DESCRIPTION
This commit adds the ability to register various persisted classes
(i.e. ETD, GenericWork) for remote identifier minting, with an initial
focus on DOI generation.

One interesting thing to note:

Once you register a persisted class as being DOI mintable; Then the
object's publisher becomes a required field IF we are assigning a
DOI for that item (if they want a DOI assigned).

Closes planning/ndlib#33
Closes planning/ndlib#159
Closes planning/ndlib#167
Closes planning/ndlib#191
Closes planning/ndlib#204
Closes planning/ndlib#205
