### PR TITLE
Updating File Characterization to be more sane

### DIFF
--- a/curate.gemspec
+++ b/curate.gemspec
@@ -28,7 +28,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'sufia-models', '~>3.4.0.rc2'
 #  s.add_dependency 'hydra', '6.1.0.rc8'
   s.add_dependency 'hydra-head', '~> 6.4.0.rc4'
-  s.add_dependency 'active-fedora', '~> 6.6.0'
+  s.add_dependency 'active-fedora'
+  s.add_dependency 'hydra-file_characterization', ">= 0.2.3"
   s.add_dependency 'hydra-batch-edit', '~> 1.1.1'
   s.add_dependency 'hydra-collections', '~> 1.2.0.rc1'
   s.add_dependency 'morphine'


### PR DESCRIPTION
Given the latest updates to Hydra::FileCharacterization, I want to
leverage those ideas.

This also fixes the build that was broken after removing the run_fits!
private method upstream.
