### PR TITLE
Adding Curate.permanent_url_for(object)

### DIFF
--- a/lib/curate.rb
+++ b/lib/curate.rb
@@ -12,4 +12,12 @@ require 'contributors_association'
 module Curate
   extend ActiveSupport::Autoload
   autoload :Ability
+
+  delegate :application_root_url, to: :configuration
+
+  module_function
+  def permanent_url_for(object)
+    File.join(Curate.configuration.application_root_url, 'show', object.noid)
+  end
+
 end

--- a/lib/curate/configuration.rb
+++ b/lib/curate/configuration.rb
@@ -1,4 +1,5 @@
 module Curate
+
   class << self
     attr_accessor :configuration
   end
@@ -19,6 +20,11 @@ module Curate
       }
     end
 
+    # Configure the application root url.
+    attr_writer :application_root_url
+    def application_root_url
+      @application_root_url || (raise RuntimeError.new("Make sure to set your Curate.configuration.application_root_url"))
+    end
 
     # When was this last built/deployed
     attr_writer :build_identifier

--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # -*- encoding : utf-8 -*-
 require 'rails/generators'
 require 'rails/generators/migration'
@@ -83,16 +85,24 @@ This generator makes the following changes to your application:
     gsub_file 'config/routes.rb', /^\s+root.+$/, "  root 'welcome#index'"
   end
 
-  def create_curate_initializer
+  def create_curate_config
     initializer 'curate_config.rb' do
       data = []
-
       data << "Curate.configure do |config|"
-      DEFAULT_CURATION_CONCERNS.each do |curation_concern|
-        data << "  config.register_curation_concern :#{curation_concern.to_s.singularize}"
-      end
+      DEFAULT_CURATION_CONCERNS.each_with_object(data) {|curation_concern, mem|
+        mem << "  config.register_curation_concern :#{curation_concern.to_s.singularize}"
+      }
+      data << "  # # You can override curate's antivirus runner by configuring a lambda \(or"
+      data << "  # # object that responds to call\)"
+      data << "  # config.default_antivirus_instance = lambda {|filename| … }"
+      data << ""
+      data << "  # # Used for constructing permanent URLs"
+      data << "  # config.application_root_url = 'https://repository.higher.edu/'"
+      data << ""
+      data << "  # # Override the file characterization runner that is used"
+      data << "  # config.characterization_runner = lambda {|filename| … }"
       data << "end"
-
+      data << ""
       data.join("\n")
     end
   end

--- a/lib/generators/curate/templates/curate_initializer.erb.rb
+++ b/lib/generators/curate/templates/curate_initializer.erb.rb
@@ -1,0 +1,16 @@
+Curate.configure do |config|
+  <%= default_curation_concerns.inspect %>
+  <% default_curation_concerns.each do |curation_concern| %>
+  config.register_curation_concern :<%= curation_concern.to_s.singularize %>
+  <% end %>
+
+  # # You can override curate's antivirus runner by configuring a lambda (or 
+  # # object that responds to call)
+  # config.default_antivirus_instance = lambda {|filename| … }
+
+  # # Used for constructing permanent URLs
+  # config.application_root_url = "https://repository.higher.edu/"
+
+  # # Override the file characterization runner that is used
+  # config.characterization_runner = lambda {|filename| … }
+end

--- a/lib/generators/curate/work/with_doi/with_doi_generator.rb
+++ b/lib/generators/curate/work/with_doi/with_doi_generator.rb
@@ -6,7 +6,7 @@ module Curate::Work
     argument :targets, type: :array, required: true, banner: "target, target"
     def append_doi_initializer
       options = targets
-      options << [%(--target='{|o| "http://localhost/concern/\#{o.class.model_name}/\#{o.to_param}" }')]
+      options << [%(--target='{|obj| Curate.permanent_url_for(obj) }')]
       options << [%(--creator=:creator)]
       options << [%(--title=:title)]
       options << [%(--publisher='{|o| Array(o.publisher).join("; ")}')]

--- a/spec/lib/curate/configuration_spec.rb
+++ b/spec/lib/curate/configuration_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+
 module Curate
   describe Configuration do
     its(:default_antivirus_instance) { should respond_to(:call)}
@@ -9,5 +10,24 @@ module Curate
       }.to change{ subject.registered_curation_concern_types }.from([]).to(['GenericWork'])
 
     end
+
+    context '#application_root_url' do
+      around(:each) do |example|
+        begin
+          old_url = subject.application_root_url
+          subject.application_root_url = nil
+          example.run
+        ensure
+          subject.application_root_url = old_url
+        end
+        it 'should require application_root_url to be configured' do
+          old_value = subject.application_root_url
+          expect {
+            subject.application_root_url
+          }.to raise_error(RuntimeError)
+        end
+      end
+    end
+
   end
 end

--- a/spec/lib/curate_spec.rb
+++ b/spec/lib/curate_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe Curate do
+  let(:curation_concern) { double(noid: "abc123") }
+
+  context '.permanent_url' do
+    it {
+      expect(Curate.permanent_url_for(curation_concern)).to eq(File.join(Curate.configuration.application_root_url, "/show/#{curation_concern.noid}"))
+    }
+  end
+
+end

--- a/spec/routing/common_objects_routing_spec.rb
+++ b/spec/routing/common_objects_routing_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 
 describe '/purl routing' do
-  it "routes GET /purl/:id" do
+  # Some implementers of Curate may be making the guarantee that this URL
+  # is permanently addressable via a remote identifier (i.e. DOI, ARK)
+  # So as not to raise the ire of both librarians and developers, don't
+  # remove this spec nor the URL!
+  it "routes GET /show/:id" do
     param_id = "12a34b56c"
     expect(get: "/show/#{param_id}").to(
       route_to(controller: "common_objects", action: "show", id: param_id)

--- a/spec/skeleton/lib/generators/test_app_generator.rb
+++ b/spec/skeleton/lib/generators/test_app_generator.rb
@@ -12,16 +12,15 @@ class TestAppGenerator < Rails::Generators::Base
       match = "  # For end to end specs, I want the exception handler capturing things; Not raising exceptions.\n  config.consider_all_requests_local = ENV['LOCAL'] || false"
     end
 
-    initializer 'curate_initializer.rb' do
+    inject_into_file 'config/initializers/curate_config.rb', after: "Curate.configure do |config|\n" do
       <<-EOV
-      Curate.configure do |config|
+        config.application_root_url = 'http://localhost'
         config.default_antivirus_instance = lambda {|file_path|
           AntiVirusScanner::NO_VIRUS_FOUND_RETURN_VALUE
         }
         config.characterization_runner = lambda {|file_path|
           Curate::Engine.root.join('spec/support/files/default_fits_output.xml').read
         }
-      end
       EOV
     end
   end


### PR DESCRIPTION
By providing a Curate.permanent_url_for method I am hoping to convey
that Curate's /show/:noid URL can be viewed as permanent and thus
we can point DOIs at that URI.

Closes ndlib/planning#204
Closes ndlib/planning#205
