### PR TITLE
Visual improvements to the header, search, work creation

### DIFF
--- a/app/assets/stylesheets/layout/positioning.css.scss
+++ b/app/assets/stylesheets/layout/positioning.css.scss
@@ -53,7 +53,7 @@ dl.stacked {
   dd {
     clear:right;
     margin:0 0 0 30%;
-    width:70%;
+    width:40%;
     word-wrap:break-word;
   }
 }
@@ -63,6 +63,20 @@ dl.stacked {
   margin-bottom: 30px;
   margin-top: 20px;
   padding-bottom: 9px;
+}
+
+.search > .row > .main-header {
+  border-bottom: none;
+  margin-bottom: 24px;
+  padding-bottom: 0;
+}
+
+.main-header > .navbar {
+  margin-bottom: 0;
+}
+
+.search .sidebar > h3:first-child {
+  margin-top: -.4em;
 }
 
 legend + .control-group {

--- a/app/assets/stylesheets/modules/site_search.css.scss
+++ b/app/assets/stylesheets/modules/site_search.css.scss
@@ -1,4 +1,6 @@
 .search-form {
+  position:relative;
+
   .search-query,
   .search-submit {
     -moz-box-sizing: border-box;
@@ -6,23 +8,19 @@
   }
 
   .search-query {
-    width:80%;
-    padding-top:1em;
-    padding-bottom:1em;
-    @include border-bottom-left-radius(15px);
-    @include border-bottom-right-radius(0);
-    @include border-top-left-radius(15px);
-    @include border-top-right-radius(0);
+    width:100%;
+    padding:1em 12% 1em .6em;
+    @include border-radius($inputBorderRadius);
   }
 
   .search-submit {
-    padding-left:0;
-    width:20%;
+    padding:2px;
+    position:absolute;
+    right:2px;
+    text-align:center;
+    top:2px;
     white-space:nowrap;
-    @include border-bottom-left-radius(0);
-    @include border-bottom-right-radius(15px);
-    @include border-top-left-radius(0);
-    @include border-top-right-radius(15px);
+    width:9%;
   }
 }
 

--- a/app/repository_models/document.rb
+++ b/app/repository_models/document.rb
@@ -1,6 +1,8 @@
 class Document < GenericWork
   has_metadata "descMetadata", type: DocumentDatastream
 
+  self.human_readable_short_description = "Deposite any text-based document (other than an article)."
+
   def self.valid_types
     [ 'Book',
       'Book Chapter',
@@ -17,7 +19,7 @@ class Document < GenericWork
 
   attribute :type, datastream: :descMetadata,
     multiple: false,
-    validates: { inclusion: { in: Document.valid_types, 
+    validates: { inclusion: { in: Document.valid_types,
                               allow_blank: true } }
 
 end

--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -13,6 +13,10 @@ class Etd < ActiveFedora::Base
   class_attribute :human_readable_short_description
   self.human_readable_short_description = "Deposit a senior thesis, master's thesis, or dissertation."
 
+  def self.human_readable_type
+    'ETD'
+  end
+
   delegate :degree, to: :descMetadata, multiple: true
 
   self.indefinite_article = 'an'

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, "#{application_name} Search Results" %>
+<% content_for :page_class, 'search' %>
 <% content_for :page_header do %>
   <div class="navbar">
     <div class="navbar-inner">

--- a/app/views/curation_concern/etds/_etd.html.erb
+++ b/app/views/curation_concern/etds/_etd.html.erb
@@ -35,7 +35,7 @@
         raw('<i class="icon-pencil icon-large"></i>'),
         edit_curation_concern_etd_path(etd),
         :class=> 'itemicon itemedit',
-        :title => 'Edit Etd')%>
+        :title => 'Edit ETD')%>
     <% end -%>
 
     <% if current_user %>

--- a/app/views/layouts/curate_nd/catalog.html.erb
+++ b/app/views/layouts/curate_nd/catalog.html.erb
@@ -4,7 +4,7 @@
   <div class="row">
 
   <% if content_for?(:sidebar) %>
-    <div class="span3">
+    <div class="span3 sidebar">
       <%= yield(:sidebar) %>
     </div>
 

--- a/app/views/shared/_site_actions.html.erb
+++ b/app/views/shared/_site_actions.html.erb
@@ -18,7 +18,7 @@
     </ul>
   </div><div class="btn-group my-actions">
     <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
-      Me <%# TODO: Make this show the display name of the current user %>
+      <%= current_user.display_name.blank? ? 'Me' : current_user.display_name %>
     <span class="caret"></span>
     </a>
     <ul class="dropdown-menu" data-no-turbolink="true">

--- a/app/views/shared/_site_search.html.erb
+++ b/app/views/shared/_site_search.html.erb
@@ -2,7 +2,7 @@
   <fieldset>
     <legend class="accessible-hidden">Search <%=t('sufia.product_name')%></legend>
     <%= label_tag :catalog_search, t('sufia.search.form.q.label'), :class => "accessible-hidden" %>
-    <%= search_as_hidden_fields(:omit_keys => [:q, :qt, :page]).html_safe %> 
+    <%= search_as_hidden_fields(:omit_keys => [:q, :qt, :page]).html_safe %>
     <%= text_field_tag(
       :q,
       params[:q],
@@ -12,8 +12,8 @@
       :size => "30",
       :tabindex => "1",
       :type => "search",
-    )%><button type="submit" class="search-submit btn btn-primary" id="search-submit-header" tabindex="2">
-      <i class="icon-search icon-white"></i> Go
+    )%><button type="submit" class="search-submit btn btn-primary" id="keyword-search-submit" tabindex="2">
+      <i class="icon-search icon-white"></i><span class="accessible-hidden">Search</span>
     </button>
   </fieldset>
 <% end %>

--- a/spec/features/article_spec.rb
+++ b/spec/features/article_spec.rb
@@ -25,7 +25,7 @@ describe 'Creating a article' do
 
       # then I should find it in the search results.
       fill_in 'Search Curate', with: 'roof party'
-      click_button 'Go'
+      click_button 'keyword-search-submit'
       within('#documents') do
         expect(page).to have_link('craft beer roof party YOLO fashion axe') #title
         expect(page).to have_selector('dd', text: 'My abstract')

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -16,7 +16,7 @@ describe 'catalog search', describe_options do
     visit('/')
     within('.search-form') do
       fill_in "Search Curate", with: 'some work'
-      click_button("Go")
+      click_button("keyword-search-submit")
     end
 
     page.should have_tag(".search-constraints", with_text: "Limited to:")
@@ -37,7 +37,7 @@ describe "Search for a work" do
       visit('/')
       within('.search-form') do
         fill_in "Search Curate", with: 'skateboard Cosby'
-        click_button("Go")
+        click_button("keyword-search-submit")
       end
 
       expect(page).to have_selector("#document_#{public_work.noid}")

--- a/spec/features/collections_spec.rb
+++ b/spec/features/collections_spec.rb
@@ -20,7 +20,7 @@ describe "Showing and creating Collections" do
 
     # then I should find it in the search results.
     fill_in 'Search Curate', with: 'amalgamate members'
-    click_button 'Go'
+    click_button 'keyword-search-submit'
     within('#documents') do
       expect(page).to have_link('amalgamate members') #title
       expect(page).to have_selector('dd', text: "I've collected a few related things together")

--- a/spec/features/dataset_spec.rb
+++ b/spec/features/dataset_spec.rb
@@ -25,7 +25,7 @@ describe 'Creating a dataset' do
 
       # then I should find it in the search results.
       fill_in 'Search Curate', with: 'fingerstache gastropub'
-      click_button 'Go'
+      click_button 'keyword-search-submit'
       within('#documents') do
         expect(page).to have_link('Banksy fingerstache Polaroid artisan gastropub') #title
         expect(page).to have_selector('dd', text: 'Test abstract')

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -287,7 +287,7 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
 
     within(".search-form") do
       fill_in("q", with: search_term)
-      click_on("Go")
+      click_on("keyword-search-submit")
     end
 
     within('#documents') do
@@ -323,7 +323,7 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
     search_term = "\"#{updated_title}\""
     within(".search-form") do
       fill_in("q", with: search_term)
-      click_on("Go")
+      click_on("keyword-search-submit")
     end
     within('#documents') do
       page.should_not have_content(updated_title)

--- a/spec/features/etd_spec.rb
+++ b/spec/features/etd_spec.rb
@@ -26,7 +26,7 @@ describe 'Creating an etd' do
 
     # then I should find it in the search results.
     fill_in 'Search Curate', with: 'sartorial umami'
-    click_button 'Go'
+    click_button 'keyword-search-submit'
     within('#documents') do
       expect(page).to have_link('umami sartorial Williamsburg church-key') #title
       expect(page).to have_selector('dd', text: 'Test etd creator')

--- a/spec/features/image_spec.rb
+++ b/spec/features/image_spec.rb
@@ -20,7 +20,7 @@ describe 'Creating an image' do
 
     # then I should find it in the search results.
     fill_in 'Search Curate', with: 'readymade paleo'
-    click_button 'Go'
+    click_button 'keyword-search-submit'
     within('#documents') do
       expect(page).to have_link('readymade shabby chic paleo ethical') #title
       expect(page).to have_selector('dd', text: '2013-10-04')

--- a/spec/features/person_profile_spec.rb
+++ b/spec/features/person_profile_spec.rb
@@ -45,7 +45,7 @@ describe 'Profile for a Person: ' do
     it 'is displayed in the results' do
       visit catalog_index_path
       fill_in 'Search Curate', with: 'Marguerite'
-      click_button 'Go'
+      click_button 'keyword-search-submit'
       within('#documents') do
         expect(page).to have_link('Marguerite Scypion') #title
       end


### PR DESCRIPTION
Capitalizing ETD as it is an acronym
Note that simple_form relies on model_name which has NOT changed.

Adding a description for Document

Remove header border on search page

Facet title alignment

Making the search button inset in the search field

Display the user's name in the header

Correcting help attribute width for box sizing
