### PR TITLE
Remove hard-coding view logic on quick classify

### DIFF
--- a/app/models/classify_concern.rb
+++ b/app/models/classify_concern.rb
@@ -2,6 +2,10 @@ require 'active_attr'
 class ClassifyConcern
   UPCOMING_CONCERNS = []
 
+  def self.normalize_concern_name(name)
+    name.to_s.classify
+  end
+
   include ActiveAttr::Model
   attribute :curation_concern_type
 

--- a/app/models/quick_classification_query.rb
+++ b/app/models/quick_classification_query.rb
@@ -1,0 +1,22 @@
+class QuickClassificationQuery
+  CURATION_CONCERNS_TO_TRY = ['article', 'dataset', 'image']
+  def self.each_for_context(*args, &block)
+    new(*args).all.each(&block)
+  end
+
+  def initialize(context, options = {})
+    @concern_name_normalizer = options.fetch(:concern_name_normalizer, ClassifyConcern.method(:normalize_concern_name))
+    @registered_curation_concern_names = options.fetch(:registered_curation_concern_names, Curate.configuration.registered_curation_concern_types)
+    @curation_concern_names_to_try = options.fetch(:curation_concern_names_to_try, CURATION_CONCERNS_TO_TRY)
+  end
+
+  def all
+    (registered_curation_concern_names & normalized_curation_concern_names).collect(&:constantize)
+  end
+
+  private
+  attr_reader :concern_name_normalizer, :registered_curation_concern_names, :curation_concern_names_to_try
+  def normalized_curation_concern_names
+    curation_concern_names_to_try.collect{|name| concern_name_normalizer.call(name) }
+  end
+end

--- a/app/views/shared/_site_actions.html.erb
+++ b/app/views/shared/_site_actions.html.erb
@@ -4,12 +4,12 @@
     <%= link_to new_classify_concern_path, id: "add-content", class: "btn btn-primary dropdown-toggle", data: { toggle: "dropdown"} do %>
       <span class="icon icon-white icon-plus"></span><span class="visuallyhidden">Add</span>
   <% end %>
-    <ul class="dropdown-menu" data-no-turbolink="true">
+    <ul class="dropdown-menu quick-create" data-no-turbolink="true">
       <li><strong class="menu-heading item-with-options">Add a Work</strong>
-      <ul class="item-options">
-        <li><%= link_to 'New Article',  new_curation_concern_article_path, class: 'item-option new-article',       role: 'menuitem' %></li>
-        <li><%= link_to 'New Dataset',  new_curation_concern_dataset_path, class: 'item-option new-dataset',       role: 'menuitem' %></li>
-        <li><%= link_to 'New Image',    new_curation_concern_image_path,   class: 'item-option new-image',         role: 'menuitem' %></li>
+      <ul class="item-options quick-classify">
+        <% QuickClassificationQuery.each_for(current_user) do |concern| %>
+          <li><%= link_to "New #{concern.human_readable_type}",  polymorphic_path([:curation_concern, concern], action: :new) class: "item-option #{dom_class(concern, 'new').gsub('_', '-')}",       role: 'menuitem' %></li>
+        <% end %>
         <li><%= link_to 'More Options', new_classify_concern_path,         class: 'item-option link-to-full-list', role: 'menuitem' %></li>
       </ul>
       </li>

--- a/lib/curate/configuration.rb
+++ b/lib/curate/configuration.rb
@@ -40,7 +40,7 @@ module Curate
 
     def register_curation_concern(*curation_concern_types)
       Array(curation_concern_types).flatten.compact.each do |cc_type|
-        class_name = cc_type.to_s.classify
+        class_name = ClassifyConcern.normalize_concern_name(cc_type)
         if ! registered_curation_concern_types.include?(class_name)
           self.registered_curation_concern_types << class_name
         end

--- a/spec/models/classify_concern_spec.rb
+++ b/spec/models/classify_concern_spec.rb
@@ -29,4 +29,8 @@ describe ClassifyConcern do
       expect(subject.upcoming_concerns).to be_kind_of(Array)
     end
   end
+
+  describe '.normalize_concern_name' do
+    it { expect(described_class.normalize_concern_name(:generic_file)).to eq('GenericFile') }
+  end
 end

--- a/spec/models/quick_classification_query_spec.rb
+++ b/spec/models/quick_classification_query_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe QuickClassificationQuery do
+  let(:normalizer) { lambda {|name| name.to_s.classify }}
+  let(:registered_curation_concern_names) { [described_class.name] }
+  let(:curation_concern_names_to_try) { ['GenericWork', described_class.name, 'Object'] }
+
+  subject { described_class.new(query_context, options) }
+  let(:options) {
+    {
+      concern_name_normalizer: normalizer,
+      registered_curation_concern_names: registered_curation_concern_names,
+      curation_concern_names_to_try: curation_concern_names_to_try
+    }
+  }
+  let(:query_context) { double }
+
+  context '#all' do
+    its(:all) { should == [described_class] }
+  end
+
+  context '.each_for_context' do
+    it 'should yield' do
+      expect {|b|
+        UserQuickClassificationQuery.each_for_context(query_context, options, &b)
+      }.to yield_successive_args(described_class)
+    end
+  end
+end


### PR DESCRIPTION
Given that Curate allows for customizing which CurationConcerns are
available, we need to be able to handle this customization.

This is a step towards that. We are envisioning that the
.quick-classify area could vary based on the context (i.e. Professor
Pie only deposits Research Paper and Datasets so lets have that be the
default; Whereas Apple is a new user and sees a different set of
options for classification)

It should be noted that prior to this change CurateND was broke
because it did not register an image as a valid work type.
