### PR TITLE
Remove hard-coding view logic on quick classify

### DIFF
--- a/app/models/classify_concern.rb
+++ b/app/models/classify_concern.rb
@@ -2,6 +2,10 @@ require 'active_attr'
 class ClassifyConcern
   UPCOMING_CONCERNS = []
 
+  def self.normalize_concern_name(name)
+    name.to_s.classify
+  end
+
   include ActiveAttr::Model
   attribute :curation_concern_type
 

--- a/app/models/quick_classification_query.rb
+++ b/app/models/quick_classification_query.rb
@@ -1,0 +1,22 @@
+class QuickClassificationQuery
+  CURATION_CONCERNS_TO_TRY = ['article', 'dataset', 'image']
+  def self.each_for_context(*args, &block)
+    new(*args).all.each(&block)
+  end
+
+  def initialize(context, options = {})
+    @concern_name_normalizer = options.fetch(:concern_name_normalizer, ClassifyConcern.method(:normalize_concern_name))
+    @registered_curation_concern_names = options.fetch(:registered_curation_concern_names, Curate.configuration.registered_curation_concern_types)
+    @curation_concern_names_to_try = options.fetch(:curation_concern_names_to_try, CURATION_CONCERNS_TO_TRY)
+  end
+
+  def all
+    (registered_curation_concern_names & normalized_curation_concern_names).collect(&:constantize)
+  end
+
+  private
+  attr_reader :concern_name_normalizer, :registered_curation_concern_names, :curation_concern_names_to_try
+  def normalized_curation_concern_names
+    curation_concern_names_to_try.collect{|name| concern_name_normalizer.call(name) }
+  end
+end

--- a/app/views/shared/_site_actions.html.erb
+++ b/app/views/shared/_site_actions.html.erb
@@ -3,13 +3,13 @@
   <div class="btn-group add-content">
     <%= link_to new_classify_concern_path, id: "add-content", class: "btn btn-primary dropdown-toggle", data: { toggle: "dropdown"} do %>
       <span class="icon icon-white icon-plus"></span><span class="visuallyhidden">Add</span>
-  <% end %>
-    <ul class="dropdown-menu" data-no-turbolink="true">
+    <% end %>
+    <ul class="dropdown-menu quick-create" data-no-turbolink="true">
       <li><strong class="menu-heading item-with-options">Add a Work</strong>
-      <ul class="item-options">
-        <li><%= link_to 'New Article',  new_curation_concern_article_path, class: 'item-option new-article',       role: 'menuitem' %></li>
-        <li><%= link_to 'New Dataset',  new_curation_concern_dataset_path, class: 'item-option new-dataset',       role: 'menuitem' %></li>
-        <li><%= link_to 'New Image',    new_curation_concern_image_path,   class: 'item-option new-image',         role: 'menuitem' %></li>
+      <ul class="item-options quick-classify">
+        <% QuickClassificationQuery.each_for_context(current_user) do |concern| %>
+          <li><%= link_to "New #{concern.human_readable_type}",  polymorphic_path([:curation_concern, concern], action: :new), class: "item-option contextual-quick-classify #{dom_class(concern, 'new').gsub('_', '-')}",       role: 'menuitem' %></li>
+        <% end %>
         <li><%= link_to 'More Options', new_classify_concern_path,         class: 'item-option link-to-full-list', role: 'menuitem' %></li>
       </ul>
       </li>
@@ -18,8 +18,9 @@
       <li class="divider"></li>
       <li><%= link_to 'Add a Section to my Profile', new_collection_path(add_to_profile: true), class: 'menu-heading new-collection', role: 'menuitem' %></li>
     </ul>
-  </div><div class="btn-group my-actions">
-    <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
+  </div>
+  <div class="btn-group my-actions">
+    <a class="btn btn-primary dropdown-toggle user-display-name" data-toggle="dropdown" href="#">
       <%= current_user.display_name.blank? ? 'Me' : current_user.display_name %>
     <span class="caret"></span>
     </a>
@@ -27,7 +28,7 @@
       <li><%= link_to 'My Works',        catalog_index_path(:'f[generic_type_sim][]' => 'Work', works: 'mine'), class: 'my-works',       role: 'menuitem' %></li>
       <li><%= link_to 'My Collections',  collections_path,                                                      class: 'my-collections', role: 'menuitem' %></li>
       <li><%= link_to 'My Profile',      person_path(current_user.person),                                      class: 'my-account',     role: 'menuitem' %></li>
-      <li><%= link_to 'My Proxies',      person_depositors_path(current_user.person),                           class: 'my-account',     role: 'menuitem' %></li>
+      <li><%= link_to 'My Proxies',      person_depositors_path(current_user.person),                           class: 'my-proxies',     role: 'menuitem' %></li>
       <li class="divider"></li>
       <li><%= link_to 'Log Out',         destroy_user_session_path,                                             class: 'log-out',        role: 'menuitem' %></li>
     </ul>

--- a/lib/curate/configuration.rb
+++ b/lib/curate/configuration.rb
@@ -40,7 +40,7 @@ module Curate
 
     def register_curation_concern(*curation_concern_types)
       Array(curation_concern_types).flatten.compact.each do |cc_type|
-        class_name = cc_type.to_s.classify
+        class_name = ClassifyConcern.normalize_concern_name(cc_type)
         if ! registered_curation_concern_types.include?(class_name)
           self.registered_curation_concern_types << class_name
         end

--- a/spec/models/classify_concern_spec.rb
+++ b/spec/models/classify_concern_spec.rb
@@ -29,4 +29,8 @@ describe ClassifyConcern do
       expect(subject.upcoming_concerns).to be_kind_of(Array)
     end
   end
+
+  describe '.normalize_concern_name' do
+    it { expect(described_class.normalize_concern_name(:generic_file)).to eq('GenericFile') }
+  end
 end

--- a/spec/models/quick_classification_query_spec.rb
+++ b/spec/models/quick_classification_query_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe QuickClassificationQuery do
+  let(:normalizer) { lambda {|name| name.to_s.classify } }
+  let(:registered_curation_concern_names) { [described_class.name] }
+  let(:curation_concern_names_to_try) { ['GenericWork', described_class.name, 'Object'] }
+
+  subject { described_class.new(query_context, options) }
+  let(:options) {
+    {
+      concern_name_normalizer: normalizer,
+      registered_curation_concern_names: registered_curation_concern_names,
+      curation_concern_names_to_try: curation_concern_names_to_try
+    }
+  }
+  let(:query_context) { double }
+
+  context '#all' do
+    its(:all) { should == [described_class] }
+  end
+
+  context '.each_for_context' do
+    it 'should yield' do
+      expect {|b|
+        described_class.each_for_context(query_context, options, &b)
+      }.to yield_successive_args(described_class)
+    end
+  end
+end

--- a/spec/views/shared/_site_actions.html.erb_spec.rb
+++ b/spec/views/shared/_site_actions.html.erb_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe 'shared/_site_actions.html.erb' do
+
+  before(:each) do
+    render partial: 'shared/site_actions.html.erb', locals: {current_user: current_user}
+  end
+
+  def have_login_section
+    have_tag('.nav-pills a.btn', with: { href: new_user_session_path } )
+  end
+
+  def have_add_content_section(&block)
+    have_tag('.add-content', &block)
+  end
+
+  def have_my_actions_section(&block)
+    have_tag('.my-actions', &block)
+  end
+
+  context 'logged in' do
+    let(:person) { double }
+    let(:display_name) { 'My Display Name' }
+    let(:current_user) { double(display_name: display_name, person: person) }
+    it 'renders a link to create a new user session' do
+      expect(rendered).to_not have_login_section
+      expect(rendered).to have_add_content_section do
+        with_tag '.quick-create' do
+          with_tag 'a.link-to-full-list', with: { href: new_classify_concern_path }
+          with_tag 'a.contextual-quick-classify', minimum: 3
+          with_tag 'a.new-collection', with: { href: new_collection_path }, text: 'Add a Collection'
+          with_tag 'a.new-collection', with: { href: new_collection_path(add_to_profile: true) }, text: 'Add a Section to my Profile'
+        end
+      end
+      expect(rendered).to have_my_actions_section do
+        with_tag '.my-actions' do
+          with_tag 'a.user-display-name', text: /#{display_name}/
+          with_tag '.dropdown-menu' do
+            with_tag 'a.my-works'
+            with_tag 'a.my-collections', with: { href: collections_path}
+            with_tag 'a.my-account', with: { href: person_path(person) }
+            with_tag 'a.my-proxies', with: { href: person_depositors_path(person) }
+            with_tag 'a.log-out', with: { href: destroy_user_session_path }
+          end
+        end
+      end
+    end
+  end
+
+  context 'not logged in' do
+    let(:current_user) { nil }
+    it 'renders a link to create a new user session' do
+      expect(rendered).to_not have_add_content_section
+      expect(rendered).to_not have_my_actions_section
+      expect(rendered).to have_login_section
+    end
+  end
+end


### PR DESCRIPTION
Given that Curate allows for customizing which CurationConcerns are
available, we need to be able to handle this customization.

This is a step towards that. We are envisioning that the
.quick-classify area could vary based on the context (i.e. Professor
Pie only deposits Research Paper and Datasets so lets have that be the
default; Whereas Apple is a new user and sees a different set of
options for classification)

It should be noted that prior to this change CurateND was broke
because it did not register an image as a valid work type.
