### PR TITLE
Use Curate::PropertiesDatastream to avoid name conflict 

### DIFF
--- a/app/repository_datastreams/curate/properties_datastream.rb
+++ b/app/repository_datastreams/curate/properties_datastream.rb
@@ -1,5 +1,5 @@
 # properties datastream: catch-all for info that didn't have another home.
-class PropertiesDatastream < ActiveFedora::OmDatastream
+class Curate::PropertiesDatastream < ActiveFedora::OmDatastream
   set_terminology do |t|
     t.root(:path=>"fields" ) 
     # This is where we put the user id of the object depositor

--- a/app/repository_models/curation_concern/model.rb
+++ b/app/repository_models/curation_concern/model.rb
@@ -14,7 +14,7 @@ module CurationConcern
       include Curate::ActiveModelAdaptor
       include Hydra::Collections::Collectible
       
-      has_metadata 'properties', type: PropertiesDatastream
+      has_metadata 'properties', type: Curate::PropertiesDatastream
       delegate_to :properties, [:relative_path, :depositor, :owner], multiple: false
       class_attribute :human_readable_short_description
     end

--- a/app/repository_models/generic_file.rb
+++ b/app/repository_models/generic_file.rb
@@ -7,7 +7,6 @@ class GenericFile < ActiveFedora::Base
   include CurationConcern::Embargoable # overrides visibility, so must come after Permissions
   include Sufia::GenericFile::Characterization
   include Curate::ActiveModelAdaptor
-  include Sufia::GenericFile::Metadata
   include Sufia::GenericFile::Versions
   include Sufia::GenericFile::Audit
   include Sufia::GenericFile::MimeTypes
@@ -19,7 +18,14 @@ class GenericFile < ActiveFedora::Base
   validates :batch, presence: true
   validates :file, presence: true, on: :create
 
-  delegate_to :properties, [:owner], multiple: false
+  has_metadata "descMetadata", type: GenericFileRdfDatastream
+  has_metadata 'properties', type: Curate::PropertiesDatastream
+  has_file_datastream "content", type: FileContentDatastream
+  has_file_datastream "thumbnail"
+  
+  delegate_to :properties, [:owner, :depositor], multiple: false
+  delegate_to :descMetadata, [:date_uploaded, :date_modified], multiple: false 
+  delegate_to :descMetadata, [:creator, :title], multiple: true
 
   class_attribute :human_readable_short_description
   self.human_readable_short_description = "An arbitrary single file."

--- a/app/repository_models/linked_resource.rb
+++ b/app/repository_models/linked_resource.rb
@@ -9,7 +9,7 @@ class LinkedResource < ActiveFedora::Base
 
   delegate_to :descMetadata, [:date_uploaded, :date_modified, :creator], multiple: false
 
-  has_metadata 'properties', type: PropertiesDatastream
+  has_metadata 'properties', type: Curate::PropertiesDatastream
   delegate_to :properties, [:relative_path, :depositor, :owner], multiple: false
 
   validates :batch, presence: true


### PR DESCRIPTION
Sufia's PropertiesDatastream sometimes was being loaded instead.  It didn't have an owner method. Namespacing the class, helps remove confusion.
