### PR TITLE
Updating rendering of profiles

### DIFF
--- a/app/helpers/curate_helper.rb
+++ b/app/helpers/curate_helper.rb
@@ -31,8 +31,9 @@ module CurateHelper
   end
 
   # options[:include_empty]
-  def curation_concern_attribute_to_html(curation_concern, method_name, label, options = {})
+  def curation_concern_attribute_to_html(curation_concern, method_name, label = nil, options = {})
     markup = ""
+    label ||= derived_label_for(curation_concern, method_name)
     subject = curation_concern.send(method_name)
     return markup if !subject.present? && !options[:include_empty]
     markup << %(<tr><th>#{label}</th>\n<td><ul class='tabular'>)
@@ -42,6 +43,11 @@ module CurateHelper
     markup << %(</ul></td></tr>)
     markup.html_safe
   end
+
+  def derived_label_for(curation_concern, method_name)
+    curation_concern.respond_to?(:label_for) ? curation_concern.label_for(method_name) : method_name.to_s.humanize.titlecase
+  end
+  private :derived_label_for
 
   def classify_for_display(curation_concern)
     curation_concern.human_readable_type.downcase

--- a/app/views/curate/people/show.html.erb
+++ b/app/views/curate/people/show.html.erb
@@ -10,14 +10,14 @@
 <% end %>
 
 <table class="table table-striped <%= dom_class(@person) %> attributes">
+  <caption class="table-heading"><h2>Attributes</h2></caption>
+  <thead>
+    <tr><th>Attribute Name</th><th>Values</th></tr>
+  </thead>
   <tbody>
-    <tr><th>Campus Phone:    </th><td><%= @person.campus_phone_number    %></td></tr>
-    <tr><th>Alternate Phone: </th><td><%= @person.alternate_phone_number %></td></tr>
-    <tr><th>Preferred Email: </th><td><%= @person.preferred_email        %></td></tr>
-    <tr><th>Alternate Email: </th><td><%= @person.alternate_email        %></td></tr>
-    <tr><th>Date of Birth:   </th><td><%= @person.date_of_birth          %></td></tr>
-    <tr><th>Personal Webpage:</th><td><%= @person.personal_webpage       %></td></tr>
-    <tr><th>Blog:            </th><td><%= @person.blog                   %></td></tr>
+    <%- @person.terms_for_display.each do |attribute_name| -%>
+      <%= curation_concern_attribute_to_html(@person, attribute_name)  %>
+    <%- end -%>
   </tbody>
 </table>
 


### PR DESCRIPTION
By using the terms_for_display, we can programatically render
attributes and their corresponding labels.

``` gherkin
Given I have filled out my Profile's display name
And I have filled out my Profile's alternate email address
And I have not filled out my Profile's phone number
When anyone views my Profile page
Then the viewer will see both the label for Display Name with my display name
And the viewer  will see both the label for Alternate Email Address with my alternate email address
And the viewer will not see a label for Phone Number nor an empty phone number
```

closes ndlib/planning#271
