### PR TITLE
Providing a Rails template

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,3 +25,19 @@ Dir.glob('tasks/*.rake').each { |r| import r }
 Bundler::GemHelper.install_tasks
 
 task :default => 'ci'
+
+task :release => ['release:update_template']
+
+namespace :release do
+
+  desc 'Make sure the application template is updated'
+  task :update_template do
+    application_template_directory = File.expand_path("../lib/generators/curate/", __FILE__)
+    application_template_erb = File.join(application_template_directory, "application_template.rb.erb")
+    application_template_output = File.join(application_template_directory, "application_template.rb")
+    buffer = ERB.new(File.read(application_template_erb)).result(binding)
+    File.open(application_template_output, 'w+') do |file|
+      file.puts buffer
+    end
+  end
+end

--- a/lib/generators/curate/application_template.rb
+++ b/lib/generators/curate/application_template.rb
@@ -1,0 +1,57 @@
+def with_git(message)
+  yield if block_given?
+  if ! options.fetch('skip_git', false)
+    git :init
+    git add: '.'
+    git commit: "-a -m '#{message}'"
+  end
+end
+def yes_with_banner?(message, banner = "*" * 80)
+  yes?("\n#{banner}\n\n#{message}\n#{banner}\nType y(es) to confirm:")
+end
+
+with_git("Initial commit")
+
+with_git("Adding curate gem") do
+  gem 'curate', "~> 0.4.1"
+end
+
+DOI_QUESTION =
+<<-QUESTION_TO_ASK
+Would you like to allow remote minting of Digital Object Identifiers (DOI)s?
+
+More information at http://simple.wikipedia.org/wiki/Doi
+QUESTION_TO_ASK
+
+with_doi_answer = yes_with_banner?(DOI_QUESTION)
+
+command = [:curate, "--with-doi=#{with_doi_answer}"]
+
+with_git("Install curate gem with#{with_doi_answer ? '' : 'out' } DOI support\n\nWith generator: #{command.join(' ')}") do
+  generate(*command)
+end
+
+JETTY_QUESTION =
+<<-QUESTION_TO_ASK
+Would you like to use jettywrapper for your SOLR and Fedora?
+
+More information at https://github.com/projecthydra/jettywrapper/
+QUESTION_TO_ASK
+
+if yes_with_banner?(JETTY_QUESTION)
+  with_git("Configuring to ignore jetty dir") do
+    append_file '.gitignore', "\njetty/\n"
+  end
+
+  with_git("Installing jettywrapper") do
+    gem 'jettywrapper', group: [:development, :test]
+    run 'bundle install'
+  end
+
+  with_git("Downloading jettywrapper") do
+    if yes_with_banner?("Would you like to download jetty now?\n\nThis will take quite awhile based on download speeds.")
+      rake "jetty:download"
+      rake "jetty:config"
+    end
+  end
+end

--- a/lib/generators/curate/application_template.rb.erb
+++ b/lib/generators/curate/application_template.rb.erb
@@ -1,0 +1,57 @@
+def with_git(message)
+  yield if block_given?
+  if ! options.fetch('skip_git', false)
+    git :init
+    git add: '.'
+    git commit: "-a -m '#{message}'"
+  end
+end
+def yes_with_banner?(message, banner = "*" * 80)
+  yes?("\n#{banner}\n\n#{message}\n#{banner}\nType y(es) to confirm:")
+end
+
+with_git("Initial commit")
+
+with_git("Adding curate gem") do
+  gem 'curate', "~> <%= Curate::VERSION %>"
+end
+
+DOI_QUESTION =
+<<-QUESTION_TO_ASK
+Would you like to allow remote minting of Digital Object Identifiers (DOI)s?
+
+More information at http://simple.wikipedia.org/wiki/Doi
+QUESTION_TO_ASK
+
+with_doi_answer = yes_with_banner?(DOI_QUESTION)
+
+command = [:curate, "--with-doi=#{with_doi_answer}"]
+
+with_git("Install curate gem with#{with_doi_answer ? '' : 'out' } DOI support\n\nWith generator: #{command.join(' ')}") do
+  generate(*command)
+end
+
+JETTY_QUESTION =
+<<-QUESTION_TO_ASK
+Would you like to use jettywrapper for your SOLR and Fedora?
+
+More information at https://github.com/projecthydra/jettywrapper/
+QUESTION_TO_ASK
+
+if yes_with_banner?(JETTY_QUESTION)
+  with_git("Configuring to ignore jetty dir") do
+    append_file '.gitignore', "\njetty/\n"
+  end
+
+  with_git("Installing jettywrapper") do
+    gem 'jettywrapper', group: [:development, :test]
+    run 'bundle install'
+  end
+
+  with_git("Downloading jettywrapper") do
+    if yes_with_banner?("Would you like to download jetty now?\n\nThis will take quite awhile based on download speeds.")
+      rake "jetty:download"
+      rake "jetty:config"
+    end
+  end
+end


### PR DESCRIPTION
Providing a Rails template

The application_template.rb is included so others can reference the
template via `rails new my_curate \
-m https://raw.github.com/ndlib/curate/master/lib/generators/curate/application_template.rb`

The application_template.rb.erb is to be part of the release process;
Its purpose is to update the version number that application_template
applies to the Rails application that is built via the template.

@TODO - Update the rake task to commit changed template before pushing
the released Gem
Ref ndlib/planning#302
