### PR TITLE
Lots of view love. Fixes ndlib/planning#263

### DIFF
--- a/app/assets/stylesheets/layout/positioning.css.scss
+++ b/app/assets/stylesheets/layout/positioning.css.scss
@@ -79,6 +79,14 @@ dl.stacked {
   margin-top: -.4em;
 }
 
+.search .welcome-text > h2:first-child {
+  margin-top: -.2em;
+}
+
+.search .call-to-action {
+  text-align: center;
+}
+
 legend + .control-group {
   margin-top: 0px;
 }

--- a/app/assets/stylesheets/modules.scss
+++ b/app/assets/stylesheets/modules.scss
@@ -1,5 +1,6 @@
 @import 'modules/accordion';
 @import 'modules/accessibility';
+@import 'modules/attributes';
 @import 'modules/classify_work';
 @import 'modules/emphatic_action_area';
 @import 'modules/forms';

--- a/app/assets/stylesheets/modules/attributes.css.scss
+++ b/app/assets/stylesheets/modules/attributes.css.scss
@@ -1,3 +1,22 @@
+.attribute-list {
+  clear:both;
+  float:left;
+  list-style-type:none;
+  margin-top:0;
+  width:100%;
+
+  dt,
+  .label {
+    float:left;
+    clear:both;
+  }
+
+  dd,
+  .value {
+    float:left;
+  }
+}
+
 .table .tabular {
   margin: 0;
   padding: 0;

--- a/app/assets/stylesheets/modules/search_results.css.scss
+++ b/app/assets/stylesheets/modules/search_results.css.scss
@@ -9,12 +9,22 @@
   margin-top: 1em;
   padding-top:.5em;
 
-  .attributes {
-    list-style-type:none;
+  .canonical-image {
+    width:80%;
+    margin-left:20%;
   }
 
-  .canonical-image {
-    width:90%;
+  .list-number {
+    position: relative;
+  }
+
+  .resource-type {
+    margin-bottom:0;
+    position:absolute;
+    right:0;
+    text-align:center;
+    top:0;
+    width:80%;
   }
 }
 

--- a/app/assets/stylesheets/style/theme.css.scss
+++ b/app/assets/stylesheets/style/theme.css.scss
@@ -21,11 +21,11 @@
 
 #site-title {
   h1 {
-    color:$blue;
-    //@include text-shadow(#FFF 0 0 1px)
     text-shadow: #fff 0 0 1px;
   }
 
+  a,
+  a:hover,
   a:visited {
     color:$blue;
   }

--- a/app/views/catalog/_add_to_collection_gui.html.erb
+++ b/app/views/catalog/_add_to_collection_gui.html.erb
@@ -15,7 +15,5 @@
     </div>
   </div>
 
-  <div>
-    <%= link_to 'Add to Collection', add_member_form_collections_path(collectible_id: document.pid), data: { toggle: "modal", target: ('#' + modal_id) }, method: :get, class: "pull-right btn add-to-collection", remote: true %>
-  </div>
+  <%= link_to 'Add to Collection', add_member_form_collections_path(collectible_id: document.pid), data: { toggle: "modal", target: ('#' + modal_id) }, method: :get, class: "pull-right btn add-to-collection", remote: true %>
 <% end %>

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,53 +1,69 @@
+<%# This is a search result view %>
 <% noid = document.noid %>
-<li id="document_<%= noid %>" class="row-fluid search-result">
-  <div class="span3">
-    <%= document_counter + 1 %>
-    <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: document} %>
+<li id="document_<%= noid %>" class="search-result">
+  <div class="row-fluid">
+
+    <div class="span3">
+      <span class="result-number"><%= document_counter + 1 %></span>
+      <%= render :partial => 'catalog/_index_partials/type_display', locals: {document: document} %>
+    </div>
+
+    <div class="span6">
+      <% solr_doc = document.inner_object.solr_doc %>
+      <%# Minimize Fedora hits by using solr_doc rather than document %>
+      <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), polymorphic_path_for_asset(document), :id => "src_copy_link_#{noid}" %>
+    </div>
+
+    <div class="span3">
+      <% if current_user -%>
+        <%= render partial: 'add_to_collection_gui', locals: { document: document } %>
+
+        <%= link_to(
+          raw('<i class="icon-pencil icon-large"></i>'),
+          edit_polymorphic_path_for_asset(document),
+            :class=> 'itemicon itemedit btn pull-right',
+            :title => 'Edit Document'
+          ) if can? :edit, document %>
+      <% end -%>
+    </div>
+
   </div>
 
-  <div class="span8">
-    <% solr_doc = document.inner_object.solr_doc %>
-    <%# Minimize Fedora hits by using solr_doc rather than document %>
-    <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), polymorphic_path_for_asset(document), :id => "src_copy_link_#{noid}" %>
-    <dl class="attributes">
-      <% if solr_doc.has?('desc_metadata__contributor_tesim') %>
-        <dt>Author(s):</dt>
+  <div class="row-fluid">
+
+    <div class="span3">
+      <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: document} %>
+    </div>
+
+    <div class="span9">
+      <dl class="attribute-list">
+        <% if solr_doc.has?('desc_metadata__contributor_tesim') %>
+          <dt>Author(s):</dt>
         <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__contributor_tesim') %></dd>
       <% end %>
 
-      <% if solr_doc.has?('desc_metadata__description_tesim') %>
-        <dt>Description:</dt>
+        <% if solr_doc.has?('desc_metadata__description_tesim') %>
+          <dt>Description:</dt>
         <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__description_tesim'), length: 150) %></dd>
       <% end %>
 
-      <% if solr_doc.has?('desc_metadata__publisher_tesim') %>
-        <dt>Publisher(s): </dt>
+        <% if solr_doc.has?('desc_metadata__publisher_tesim') %>
+          <dt>Publisher(s): </dt>
         <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__publisher_tesim') %></dd>
       <% end %>
-    </dl>
+      </dl>
 
-    <dl class="extended-attributes hide">
-      <% index_fields.each do |solr_fname, field| -%>
-        <% if should_render_index_field? document.inner_object.solr_doc, field %>
-          <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label :field => solr_fname %></dt>
-          <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_value :document=>document.inner_object.solr_doc, :field => solr_fname %></dd>
+      <a href="" title="Click for more details"><i id="expand_<%= noid %>" class="icon-plus icon-large show-details"></i></a>&nbsp;
+
+      <dl class="attribute-list extended-attributes hide">
+        <% index_fields.each do |solr_fname, field| -%>
+          <% if should_render_index_field? document.inner_object.solr_doc, field %>
+            <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label :field => solr_fname %></dt>
+            <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_value :document=>document.inner_object.solr_doc, :field => solr_fname %></dd>
+          <% end -%>
         <% end -%>
-      <% end -%>
-    </dl>
-  </div>
-
-  <div class="span1">
-    <a href="" title="Click for more details"><i id="expand_<%= noid %>" class="icon-plus icon-large fleft show-details"></i></a>&nbsp;
-    <% if current_user -%>
-      <%= link_to(
-        raw('<i class="icon-pencil icon-large"></i>'),
-        edit_polymorphic_path_for_asset(document),
-        :class=> 'itemicon itemedit',
-        :title => 'Edit File'
-      ) if can? :edit, document %>
-
-      <%= render partial: 'add_to_collection_gui', locals: { document: document } %>
-    <% end -%>
+      </dl>
+    </div>
 
   </div>
 </li>

--- a/app/views/catalog/_home.html.erb
+++ b/app/views/catalog/_home.html.erb
@@ -1,2 +1,9 @@
+<% content_for :content_class, 'welcome-text' %>
+<% content_for :call_to_action do %>
+  <%= link_to new_classify_concern_path, :class => "btn btn-large btn-primary" do %>
+    <span class="icon icon-white icon-file"></span> Share Your Work
+  <% end %>
+<% end %>
+
 <h2>What is <%=t('sufia.product_name') %>?</h2>
 <%= render 'home_text' %>

--- a/app/views/catalog/_index_partials/_thumbnail_display.html.erb
+++ b/app/views/catalog/_index_partials/_thumbnail_display.html.erb
@@ -1,3 +1,1 @@
 <%= image_tag 'curate/nope.png', class: "canonical-image" %>
-<p class="resource-type"><%= render_index_field_value :document=>document.inner_object.solr_doc, :field => 'human_readable_type_tesim' %></p>
-<p class="resource-type"><%= render_index_field_value :document=>document.inner_object.solr_doc, :field => 'desc_metadata__resource_type_tesim' %></p>

--- a/app/views/catalog/_index_partials/_type_display.html.erb
+++ b/app/views/catalog/_index_partials/_type_display.html.erb
@@ -1,0 +1,4 @@
+<p class="resource-type">
+  <%= render_index_field_value document: document.inner_object.solr_doc, field: 'human_readable_type_tesim' %>
+  <%= render_index_field_value document: document.inner_object.solr_doc, field: 'desc_metadata__resource_type_tesim' %>
+</p>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -4,9 +4,9 @@
   <div class="navbar">
     <div class="navbar-inner">
       <ul class="nav">
-        <%= type_tab 'Works', 'Work' %> 
-        <%= type_tab 'Collections', 'Collection' %> 
-        <%= type_tab 'People', 'Person' %> 
+        <%= type_tab 'Works', 'Work' %>
+        <%= type_tab 'Collections', 'Collection' %>
+        <%= type_tab 'People', 'Person' %>
         <%= all_type_tab %>
       </ul>
     </div>
@@ -16,10 +16,6 @@
 
   <%= render 'facets' %>
 
-<% end %>
-
-<% unless has_search_parameters? %>
-  <%= render 'home' %>
 <% end %>
 
 <% if has_search_parameters? %>
@@ -38,10 +34,25 @@
       <%= render 'sort_and_per_page' %>
     </div>
   </div>
-<% end %>
 
 <%= render 'results_pagination' %>
 
 <%= render 'document_list' %>
 
 <%= render 'results_pagination' %>
+
+<% else %>
+
+  <% if current_user %>
+
+    <%= render 'results_pagination' %>
+
+    <%= render 'document_list' %>
+
+    <%= render 'results_pagination' %>
+
+  <% else %>
+    <%= render 'home' %>
+  <% end %>
+
+<% end %>

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -1,42 +1,54 @@
 <%# This is a search result view %>
 <% noid = collection.noid %>
-<li id="document_<%= noid %>" class="row-fluid search-result">
-  <div class="span3">
-    <%= collection_counter + 1 %>
-    <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: collection} %>
+<li id="document_<%= noid %>" class="search-result">
+
+  <div class="row-fluid">
+
+    <div class="span2 list-number">
+      <%= collection_counter + 1 %>
+      <%= render :partial => 'catalog/_index_partials/type_display', locals: {document: collection} %>
+    </div>
+
+    <div class="span6">
+      <% solr_doc = collection.inner_object.solr_doc %>
+      <%# Minimize Fedora hits by using solr_doc rather than document %>
+      <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), collection, :id => "src_copy_link_#{noid}" %>
+    </div>
+
+    <div class="span4">
+      <% if current_user %>
+        <%= render partial: 'add_to_collection_gui', locals: { document: collection } %>
+
+        <%= link_to(
+          raw('<i class="icon-pencil icon-large"></i>'),
+          edit_collection_path(collection),
+            :class=> 'itemicon itemedit btn pull-right',
+            :title => 'Edit Collection'
+          ) if can? :edit, collection %>
+      <% end -%>
+    </div>
+
   </div>
 
-  <div class="span8">
-    <% solr_doc = collection.inner_object.solr_doc %>
-    <%# Minimize Fedora hits by using solr_doc rather than document %>
-    <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), collection, :id => "src_copy_link_#{noid}" %>
-    <dl class="attributes">
-      <% if solr_doc.has?('desc_metadata__description_tesim') %>
-        <dt>Description:</dt>
-        <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__description_tesim'), length: 150) %></dd>
-      <% end %>
-      <% if solr_doc.has?('edit_access_person_ssim') %>
-        <dt>Owner:</dt>
-        <dd><%= render_index_field_value(document: solr_doc, field: 'edit_access_person_ssim') %></dd>
-      <% end %>
+  <div class="row-fluid">
 
-    </dl>
+    <div class="span2">
+      <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: collection} %>
+    </div>
 
-  </div>
+    <div class="span10">
+      <dl class="attribute-list">
+        <% if solr_doc.has?('desc_metadata__description_tesim') %>
+          <dt>Description:</dt>
+          <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__description_tesim'), length: 150) %></dd>
+        <% end %>
 
-  <div class="span1">
-    <% if current_user && can?(:edit, collection) %>
-      <%= link_to(
-        raw('<i class="icon-pencil icon-large"></i>'),
-        edit_collection_path(collection),
-        :class=> 'itemicon itemedit',
-        :title => 'Edit Collection')%>
-    <% end -%>
+        <% if solr_doc.has?('edit_access_person_ssim') %>
+          <dt>Owner:</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'edit_access_person_ssim') %></dd>
+        <% end %>
+    </div>
 
-    <% if current_user -%>
-      <%= render partial: 'add_to_collection_gui', locals: { document: collection } %>
-    <% end -%>
   </div>
 
 </li>
-

--- a/app/views/curate/people/show.html.erb
+++ b/app/views/curate/people/show.html.erb
@@ -8,34 +8,43 @@
   <% end %>
 </hgroup>
 <% end %>
+<div class="row">
+  <div class="span12">
+    <dl class="attribute-list <%= dom_class(@person) %>">
+    <%# This is where I tell Jeremy I'm sorry. %>
+    <% @person.terms_for_display.reject{|name| name == :name}.each do |attribute_name| %>
+      <% if @person.send(attribute_name).present? %>
+        <dt><%="#{derived_label_for( @person, attribute_name) }:" %></dt>
+        <% [@person.send(attribute_name)].flatten.compact.each do |value| %>
+        <dd><%= value %></dd>
+        <% end %>
+      <% end %>
+    <% end %>
+    </dl>
 
-<table class="table table-striped <%= dom_class(@person) %> attributes">
-  <caption class="table-heading"><h2>Attributes</h2></caption>
-  <thead>
-    <tr><th>Attribute Name</th><th>Values</th></tr>
-  </thead>
-  <tbody>
-    <%- @person.terms_for_display.each do |attribute_name| -%>
-      <%= curation_concern_attribute_to_html(@person, attribute_name)  %>
-    <%- end -%>
-  </tbody>
-</table>
-
-<%# TODO: Only render the action area if you have permission to edit the person %>
-<div class="form-action">
-  <%= link_to "Update Personal Information", edit_user_registration_path, class: 'btn btn-primary' %>
-  <% if can_edit_profile_collection?(@person) %>
-    <%= link_to 'Add a Section to my Profile', new_collection_path(add_to_profile: true), class: 'btn btn-primary' %>
-  <% end %>
-</div>
-
-<div id="person_profile">
-  <% if profile_has_contents?(@person) %>
-    <h3><%= "Selected Works of #{@person.name}" %> </h3>
-    <p><%= @person.profile.description %> </p>
-
-    <div id="documents" class="clear">
-      <%= list_items_in_collection(@person.profile) %>
+  <% if can? :edit, @person %>
+    <div class="form-action">
+      <%= link_to "Update Personal Information", edit_user_registration_path, class: 'btn btn-primary' %>
     </div>
   <% end %>
+  </div>
+</div>
+
+<div class="row">
+  <div id="person_profile" class="span12">
+    <% if profile_has_contents?(@person) %>
+      <h3><%= "Selected Works of #{@person.name}" %> </h3>
+      <p><%= @person.profile.description %> </p>
+
+      <div id="documents" class="clear">
+        <%= list_items_in_collection(@person.profile) %>
+      </div>
+    <% end %>
+
+    <% if can_edit_profile_collection?(@person) %>
+      <div class="form-action">
+        <%= link_to 'Add a Section to my Profile', new_collection_path(add_to_profile: true), class: 'btn btn-primary' %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/curation_concern/articles/_article.html.erb
+++ b/app/views/curation_concern/articles/_article.html.erb
@@ -1,42 +1,55 @@
 <%# This is a search result view %>
 <% noid = article.noid %>
-<li id="document_<%= noid %>" class="row-fluid search-result">
-  <div class="span3">
-    <%= article_counter + 1 %>
-    <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: article} %>
+<li id="document_<%= noid %>" class="search-result">
+
+  <div class="row-fluid">
+
+    <div class="span2 list-number">
+      <%= article_counter + 1 %>
+      <%= render :partial => 'catalog/_index_partials/type_display', locals: {document: article} %>
+    </div>
+
+    <div class="span6">
+      <% solr_doc = article.inner_object.solr_doc %>
+      <%# Minimize Fedora hits by using solr_doc rather than document %>
+      <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), curation_concern_article_path(article), :id => "src_copy_link_#{noid}" %>
+    </div>
+
+    <div class="span4">
+      <% if current_user %>
+        <%= render partial: 'add_to_collection_gui', locals: { document: article } %>
+
+        <%= link_to(
+          raw('<i class="icon-pencil icon-large"></i>'),
+          edit_curation_concern_article_path(article),
+            :class=> 'itemicon itemedit btn pull-right',
+            :title => 'Edit Article'
+          ) if can? :edit, article %>
+      <% end -%>
+    </div>
+
   </div>
 
-  <div class="span8">
-    <% solr_doc = article.inner_object.solr_doc %>
-    <%# Minimize Fedora hits by using solr_doc rather than document %>
-    <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), curation_concern_article_path(article), :id => "src_copy_link_#{noid}" %>
-    <dl class="attributes">
-      <% if solr_doc.has?('desc_metadata__contributor_tesim') %>
-        <dt>Contributor(s):</dt>
-        <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__contributor_tesim') %></dd>
-      <% end %>
+  <div class="row-fluid">
 
-      <% if solr_doc.has?('desc_metadata__abstract_tesim') %>
-        <dt>Abstract:</dt>
-        <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__abstract_tesim'), length: 150) %></dd>
-      <% end %>
-    </dl>
+    <div class="span2">
+      <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: article} %>
+    </div>
 
-  </div>
+    <div class="span10">
+      <dl class="attribute-list">
+        <% if solr_doc.has?('desc_metadata__contributor_tesim') %>
+          <dt>Author(s):</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__contributor_tesim') %></dd>
+        <% end %>
 
-  <div class="span1">
-    <% if current_user && can?(:edit, article) %>
-      <%= link_to(
-        raw('<i class="icon-pencil icon-large"></i>'),
-        edit_curation_concern_article_path(article),
-        :class=> 'itemicon itemedit',
-        :title => 'Edit Article')%>
-    <% end -%>
+        <% if solr_doc.has?('desc_metadata__abstract_tesim') %>
+          <dt>Abstract:</dt>
+          <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__abstract_tesim'), length: 150) %></dd>
+        <% end %>
+      </dl>
+    </div>
 
-    <% if current_user -%>
-      <%= render partial: 'add_to_collection_gui', locals: { document: article } %>
-    <% end -%>
   </div>
 
 </li>
-

--- a/app/views/curation_concern/datasets/_dataset.html.erb
+++ b/app/views/curation_concern/datasets/_dataset.html.erb
@@ -1,42 +1,55 @@
 <%# This is a search result view %>
 <% noid = dataset.noid %>
-<li id="document_<%= noid %>" class="row-fluid search-result">
-  <div class="span3">
-    <%= dataset_counter + 1 %>
-    <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: dataset} %>
+<li id="document_<%= noid %>" class="search-result">
+
+  <div class="row-fluid">
+
+    <div class="span2 list-number">
+      <%= dataset_counter + 1 %>
+      <%= render :partial => 'catalog/_index_partials/type_display', locals: {document: dataset} %>
+    </div>
+
+    <div class="span6">
+      <% solr_doc = dataset.inner_object.solr_doc %>
+      <%# Minimize Fedora hits by using solr_doc rather than document %>
+      <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), curation_concern_dataset_path(dataset), :id => "src_copy_link_#{noid}" %>
+    </div>
+
+    <div class="span4">
+      <% if current_user -%>
+        <%= render partial: 'add_to_collection_gui', locals: { document: dataset } %>
+
+        <%= link_to(
+          raw('<i class="icon-pencil icon-large"></i>'),
+          edit_curation_concern_dataset_path(dataset),
+            :class=> 'itemicon itemedit btn pull-right',
+            :title => 'Edit Dataset'
+          ) if can? :edit, dataset %>
+      <% end -%>
+    </div>
+
   </div>
 
-  <div class="span8">
-    <% solr_doc = dataset.inner_object.solr_doc %>
-    <%# Minimize Fedora hits by using solr_doc rather than document %>
-    <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), curation_concern_dataset_path(dataset), :id => "src_copy_link_#{noid}" %>
-    <dl class="attributes">
-      <% if solr_doc.has?('desc_metadata__contributor_tesim') %>
-        <dt>Contributor(s):</dt>
-        <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__contributor_tesim') %></dd>
-      <% end %>
+  <div class="row-fluid">
 
-      <% if solr_doc.has?('desc_metadata__description_tesim') %>
-        <dt>Abstract:</dt>
-        <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__description_tesim'), length: 150) %></dd>
-      <% end %>
-    </dl>
+    <div class="span2">
+      <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: dataset} %>
+    </div>
 
-  </div>
+    <div class="span10">
+      <dl class="attribute-list">
+        <% if solr_doc.has?('desc_metadata__contributor_tesim') %>
+          <dt>Contributors(s):</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__contributor_tesim') %></dd>
+        <% end %>
 
-  <div class="span1">
-    <% if current_user && can?(:edit, dataset) %>
-      <%= link_to(
-        raw('<i class="icon-pencil icon-large"></i>'),
-        edit_curation_concern_dataset_path(dataset),
-        :class=> 'itemicon itemedit',
-        :title => 'Edit Dataset')%>
-    <% end -%>
+        <% if solr_doc.has?('desc_metadata__description_tesim') %>
+          <dt>Description:</dt>
+          <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__description_tesim'), length: 150) %></dd>
+        <% end %>
+      </dl>
+    </div>
 
-    <% if current_user %>
-      <%= render partial: 'add_to_collection_gui', locals: { document: dataset } %>
-    <% end -%>
   </div>
 
 </li>
-

--- a/app/views/curation_concern/datasets/_form_required_information.html.erb
+++ b/app/views/curation_concern/datasets/_form_required_information.html.erb
@@ -1,0 +1,21 @@
+<div class="span6">
+  <fieldset class="required">
+    <legend>Required Information</legend>
+
+    <%= f.input :title,
+                input_html: { class: 'input-xlarge' }
+    %>
+
+    <%= render partial: 'linked_contributors', locals: {f: f} %>
+
+    <%= f.input :description,
+                as: :text,
+                hint: 'Please keep your description to 300 words or less.',
+                input_html: {
+                  class: 'input-xxxlarge',
+                  rows: '14'
+                },
+                label: 'Description'
+    %>
+  </fieldset>
+</div>

--- a/app/views/curation_concern/documents/_document.html.erb
+++ b/app/views/curation_concern/documents/_document.html.erb
@@ -1,57 +1,73 @@
+<%# This is a search result view %>
 <% noid = document.noid %>
-<li id="document_<%= noid %>" class="row-fluid search-result">
-  <div class="span3">
-    <%= document_counter + 1 %>
-    <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: document} %>
-  </div>
+<li id="document_<%= noid %>" class="search-result">
 
-  <div class="span8">
-    <% solr_doc = document.inner_object.solr_doc %>
-    <%# Minimize Fedora hits by using solr_doc rather than document %>
-    <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), polymorphic_path_for_asset(document), :id => "src_copy_link_#{noid}" %>
-    <dl class="attributes">
-      <% if solr_doc.has?('desc_metadata__contributor_tesim') %>
-        <dt>Author(s):</dt>
-        <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__contributor_tesim') %></dd>
-      <% end %>
+  <div class="row-fluid">
 
-      <% if solr_doc.has?('desc_metadata__description_tesim') %>
-        <dt>Description:</dt>
-        <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__description_tesim'), length: 150) %></dd>
-      <% end %>
+    <div class="span2 list-number">
+      <%= document_counter + 1 %>
+      <%= render :partial => 'catalog/_index_partials/type_display', locals: {document: document} %>
+    </div>
 
-      <% if solr_doc.has?('desc_metadata__publisher_tesim') %>
-        <dt>Publisher(s): </dt>
-        <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__publisher_tesim') %></dd>
-      <% end %>
-      <% if solr_doc.has?('desc_metadata__type_tesim') %>
-        <dt>Document Type:</dt>
-        <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__type_tesim') %></dd>
-      <% end %>
-    </dl>
+    <div class="span6">
+      <% solr_doc = document.inner_object.solr_doc %>
+      <%# Minimize Fedora hits by using solr_doc rather than document %>
+      <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), curation_concern_document_path(document), :id => "src_copy_link_#{noid}" %>
+    </div>
 
-    <dl class="extended-attributes hide">
-      <% index_fields.each do |solr_fname, field| -%>
-        <% if should_render_index_field? document.inner_object.solr_doc, field %>
-          <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label :field => solr_fname %></dt>
-          <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_value :document=>document.inner_object.solr_doc, :field => solr_fname %></dd>
-        <% end -%>
+    <div class="span4">
+      <% if current_user -%>
+        <%= render partial: 'add_to_collection_gui', locals: { document: document } %>
+
+        <%= link_to(
+          raw('<i class="icon-pencil icon-large"></i>'),
+          edit_curation_concern_document_path(document),
+            :class=> 'itemicon itemedit btn pull-right',
+            :title => 'Edit Document'
+          ) if can? :edit, document %>
       <% end -%>
-    </dl>
-  </div>
-
-  <div class="span1">
-    <a href="" title="Click for more details"><i id="expand_<%= noid %>" class="icon-plus icon-large fleft show-details"></i></a>&nbsp;
-    <% if current_user -%>
-      <%= link_to(
-        raw('<i class="icon-pencil icon-large"></i>'),
-        edit_polymorphic_path_for_asset(document),
-        :class=> 'itemicon itemedit',
-        :title => 'Edit File'
-      ) if can? :edit, document %>
-
-      <%= render partial: 'add_to_collection_gui', locals: { document: document } %>
-    <% end -%>
+    </div>
 
   </div>
+
+  <div class="row-fluid">
+
+    <div class="span2">
+      <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: document} %>
+    </div>
+
+    <div class="span10">
+      <dl class="attribute-list">
+        <% if solr_doc.has?('desc_metadata__contributor_tesim') %>
+          <dt>Author(s):</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__contributor_tesim') %></dd>
+        <% end %>
+
+        <% if solr_doc.has?('desc_metadata__description_tesim') %>
+          <dt>Description:</dt>
+          <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__description_tesim'), length: 150) %></dd>
+        <% end %>
+
+        <% if solr_doc.has?('desc_metadata__publisher_tesim') %>
+          <dt>Publisher(s): </dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__publisher_tesim') %></dd>
+        <% end %>
+        <% if solr_doc.has?('desc_metadata__type_tesim') %>
+          <dt>Document Type:</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__type_tesim') %></dd>
+        <% end %>
+      </dl>
+
+      <dl class="attribute-list extended-attributes hide">
+        <% index_fields.each do |solr_fname, field| -%>
+          <% if should_render_index_field? document.inner_object.solr_doc, field %>
+            <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label :field => solr_fname %></dt>
+            <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_value :document=>document.inner_object.solr_doc, :field => solr_fname %></dd>
+          <% end -%>
+        <% end -%>
+      </dl>
+    </div>
+
+  </div>
+
 </li>

--- a/app/views/curation_concern/etds/_etd.html.erb
+++ b/app/views/curation_concern/etds/_etd.html.erb
@@ -1,48 +1,60 @@
 <%# This is a search result view %>
 <% noid = etd.noid %>
-<li id="document_<%= noid %>" class="row-fluid search-result">
-  <div class="span3">
-    <%= etd_counter + 1 %>
-    <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: etd} %>
+<li id="document_<%= noid %>" class="search-result">
+
+  <div class="row-fluid">
+
+    <div class="span2 list-number">
+      <%= etd_counter + 1 %>
+      <%= render :partial => 'catalog/_index_partials/type_display', locals: {document: etd} %>
+    </div>
+
+    <div class="span6">
+      <% solr_doc = etd.inner_object.solr_doc %>
+      <%# Minimize Fedora hits by using solr_doc rather than document %>
+      <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), curation_concern_etd_path(etd), :id => "src_copy_link_#{noid}" %>
+    </div>
+
+    <div class="span4">
+      <% if current_user -%>
+        <%= render partial: 'add_to_collection_gui', locals: { document: etd } %>
+
+        <%= link_to(
+          raw('<i class="icon-pencil icon-large"></i>'),
+          edit_curation_concern_etd_path(etd),
+            :class=> 'itemicon itemedit btn pull-right',
+            :title => 'Edit ETD'
+          ) if can? :edit, etd %>
+      <% end -%>
+    </div>
+
   </div>
 
-  <div class="span8">
-    <% solr_doc = etd.inner_object.solr_doc %>
-    <%# Minimize Fedora hits by using solr_doc rather than document %>
-    <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), curation_concern_etd_path(etd), :id => "src_copy_link_#{noid}" %>
-    <dl class="attributes">
-      <% if solr_doc.has?('desc_metadata__contributor_tesim') %>
-        <dt>Creator(s):</dt>
-        <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__contributor_tesim') %></dd>
-      <% end %>
+  <div class="row-fluid">
 
-      <% if solr_doc.has?('desc_metadata__subject_tesim') %>
-        <dt>Subject:</dt>
-        <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__subject_tesim'), length: 150) %></dd>
-      <% end %>
+    <div class="span2">
+      <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: etd} %>
+    </div>
 
-      <% if solr_doc.has?('desc_metadata__date_created_dtsim') %>
-        <dt>Date:</dt>
-        <dd><%= Date.parse(solr_doc['desc_metadata__date_created_dtsim'].first) %></dd>
-      <% end %>
-    </dl>
+    <div class="span10">
+      <dl class="attribute-list">
+        <% if solr_doc.has?('desc_metadata__contributor_tesim') %>
+          <dt>Author(s):</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__contributor_tesim') %></dd>
+        <% end %>
 
-  </div>
+        <% if solr_doc.has?('desc_metadata__subject_tesim') %>
+          <dt>Subject:</dt>
+          <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__subject_tesim'), length: 150) %></dd>
+        <% end %>
 
-  <div class="span1">
-    <% if current_user && can?(:edit, etd) %>
-      <%= link_to(
-        raw('<i class="icon-pencil icon-large"></i>'),
-        edit_curation_concern_etd_path(etd),
-        :class=> 'itemicon itemedit',
-        :title => 'Edit ETD')%>
-    <% end -%>
+        <% if solr_doc.has?('desc_metadata__date_created_dtsim') %>
+          <dt>Date:</dt>
+          <dd><%= Date.parse(solr_doc['desc_metadata__date_created_dtsim'].first) %></dd>
+        <% end %>
+      </dl>
+    </div>
 
-    <% if current_user %>
-      <%= render partial: 'add_to_collection_gui', locals: { document: etd } %>
-    <% end -%>
   </div>
 
 </li>
-
-

--- a/app/views/curation_concern/images/_image.html.erb
+++ b/app/views/curation_concern/images/_image.html.erb
@@ -1,48 +1,60 @@
 <%# This is a search result view %>
 <% noid = image.noid %>
-<li id="document_<%= noid %>" class="row-fluid search-result">
-  <div class="span3">
-    <%= image_counter + 1 %>
-    <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: image} %>
+<li id="document_<%= noid %>" class="search-result">
+
+  <div class="row-fluid">
+
+    <div class="span2 list-number">
+      <%= image_counter + 1 %>
+      <%= render :partial => 'catalog/_index_partials/type_display', locals: {document: image} %>
+    </div>
+
+    <div class="span6">
+      <% solr_doc = image.inner_object.solr_doc %>
+      <%# Minimize Fedora hits by using solr_doc rather than document %>
+      <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), curation_concern_image_path(image), :id => "src_copy_link_#{noid}" %>
+    </div>
+
+    <div class="span4">
+      <% if current_user -%>
+        <%= render partial: 'add_to_collection_gui', locals: { document: image } %>
+
+        <%= link_to(
+          raw('<i class="icon-pencil icon-large"></i>'),
+          edit_curation_concern_image_path(image),
+            :class=> 'itemicon itemedit btn pull-right',
+            :title => 'Edit Image'
+          ) if can? :edit, image %>
+      <% end -%>
+    </div>
+
   </div>
 
-  <div class="span8">
-    <% solr_doc = image.inner_object.solr_doc %>
-    <%# Minimize Fedora hits by using solr_doc rather than document %>
-    <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), curation_concern_image_path(image), :id => "src_copy_link_#{noid}" %>
-    <dl class="attributes">
-      <% if solr_doc.has?('desc_metadata__contributor_tesim') %>
-        <dt>Creator(s):</dt>
-        <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__contributor_tesim') %></dd>
-      <% end %>
+  <div class="row-fluid">
 
-      <% if solr_doc.has?('desc_metadata__description_tesim') %>
-        <dt>Description:</dt>
-        <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__description_tesim'), length: 150) %></dd>
-      <% end %>
+    <div class="span2">
+      <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: image} %>
+    </div>
 
-      <% if solr_doc.has?('desc_metadata__date_created_dtsim') %>
-        <dt>Date:</dt>
-        <dd><%= Date.parse(solr_doc['desc_metadata__date_created_dtsim'].first) %></dd>
-      <% end %>
-    </dl>
+    <div class="span10">
+      <dl class="attribute-list">
+        <% if solr_doc.has?('desc_metadata__contributor_tesim') %>
+          <dt>Creator(s):</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__contributor_tesim') %></dd>
+        <% end %>
 
-  </div>
+        <% if solr_doc.has?('desc_metadata__description_tesim') %>
+          <dt>Description:</dt>
+          <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__description_tesim'), length: 150) %></dd>
+        <% end %>
 
+        <% if solr_doc.has?('desc_metadata__date_created_dtsim') %>
+          <dt>Date:</dt>
+          <dd><%= Date.parse(solr_doc['desc_metadata__date_created_dtsim'].first) %></dd>
+        <% end %>
+      </dl>
+    </div>
 
-  <div class="span1">
-    <% if current_user && can?(:edit, image) %>
-      <%= link_to(
-        raw('<i class="icon-pencil icon-large"></i>'),
-        edit_curation_concern_image_path(image),
-        :class=> 'itemicon itemedit',
-        :title => 'Edit Image')%>
-    <% end -%>
-
-    <% if current_user %>
-      <%= render partial: 'add_to_collection_gui', locals: { document: image } %>
-    <% end %>
   </div>
 
 </li>
-

--- a/app/views/curation_concern/people/_person.html.erb
+++ b/app/views/curation_concern/people/_person.html.erb
@@ -1,21 +1,39 @@
 <%# This is a search result view %>
 <% noid = person.noid %>
-<li id="document_<%= noid %>" class="row-fluid search-result">
-  <div class="span3">
-    <%= person_counter + 1 %>
-    <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: person} %>
+<li id="document_<%= noid %>" class="search-result">
+
+  <div class="row-fluid">
+
+    <div class="span2 list-number">
+      <%= person_counter + 1 %>
+      <%= render :partial => 'catalog/_index_partials/type_display', locals: {document: person} %>
+    </div>
+
+    <div class="span6">
+      <% solr_doc = person.inner_object.solr_doc %>
+      <%# Minimize Fedora hits by using solr_doc rather than document %>
+      <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__name_tesim'), person, :id => "src_copy_link_#{noid}" %>
+    </div>
+
+    <div class="span4">
+      <% if current_user -%>
+        <%= render partial: 'add_to_collection_gui', locals: { document: person } %>
+      <% end -%>
+    </div>
+
   </div>
 
-  <div class="span8">
-    <% solr_doc = person.inner_object.solr_doc %>
-    <%# Minimize Fedora hits by using solr_doc rather than document %>
-    <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__name_tesim'), person, :id => "src_copy_link_#{noid}" %>
-    <dl class="attributes">
-    </dl>
+  <div class="row-fluid">
+
+    <div class="span2">
+      <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: person} %>
+    </div>
+
+    <div class="span10">
+      <dl class="attribute-list">
+      </dl>
+    </div>
+
   </div>
 
-  <% if current_user -%>
-    <%= render partial: 'add_to_collection_gui', locals: { document: person } %>
-  <% end -%>
 </li>
-

--- a/app/views/layouts/curate_nd.html.erb
+++ b/app/views/layouts/curate_nd.html.erb
@@ -16,8 +16,7 @@
             </div>
 
             <div id="site-title" class="span4">
-              <%# NOTE: The product_name SHOULD link to the root URL, but the root URL should also be the catalog index; specs to follow %>
-              <h1><%= link_to t('sufia.product_name'), catalog_index_path, tabindex: :'-1' %></h1>
+              <h1><%= link_to t('sufia.product_name'), root_path %></h1>
             </div>
 
             <nav id="site-actions" class="span4" role="menu">

--- a/app/views/layouts/curate_nd/catalog.html.erb
+++ b/app/views/layouts/curate_nd/catalog.html.erb
@@ -2,19 +2,35 @@
 <% content_for :main do %>
 
   <div class="row">
-
   <% if content_for?(:sidebar) %>
+
     <div class="span3 sidebar">
       <%= yield(:sidebar) %>
     </div>
 
-    <div class="span9">
-  <% else %>
-    <div class="span12">
-  <% end %>
+    <% if content_for?(:call_to_action) %>
+      <div class="span6 <%= yield(:content_class) %>">
+    <% else %>
+      <div class="span9 <%= yield(:content_class) %>">
+    <% end %>
       <%= yield %>
     </div>
 
+    <% if content_for?(:call_to_action) %>
+
+    <div class="span3 call-to-action">
+      <%= yield(:call_to_action) %>
+    </div>
+
+    <% end %>
+
+  <% else %>
+
+    <div class="span12">
+      <%= yield %>
+    </div>
+
+  <% end %>
   </div>
 
 <% end %>

--- a/spec/features/dataset_spec.rb
+++ b/spec/features/dataset_spec.rb
@@ -12,7 +12,7 @@ describe 'Creating a dataset' do
       within '#new_dataset' do
         fill_in "Title", with: "Banksy fingerstache Polaroid artisan gastropub"
         fill_in "Contributor", with: "Test dataset contributor"
-        fill_in "Abstract", with: "Test abstract"
+        fill_in "Description", with: "This dataset is for testing purposes"
         fill_in "External link", with: "http://www.youtube.com/watch?v=oHg5SJYRHA0"
         select(Sufia.config.cc_licenses.keys.first, from: I18n.translate('sufia.field_label.rights'))
         check("I have read and accept the contributor license agreement")
@@ -28,7 +28,7 @@ describe 'Creating a dataset' do
       click_button 'keyword-search-submit'
       within('#documents') do
         expect(page).to have_link('Banksy fingerstache Polaroid artisan gastropub') #title
-        expect(page).to have_selector('dd', text: 'Test abstract')
+        expect(page).to have_selector('dd', text: 'This dataset is for testing purposes')
         expect(page).to have_selector('dd', text: 'Test dataset contributor')
       end
     end


### PR DESCRIPTION
This tries to do a bunch of things:
- Hide results when displaying a blank search
- Link site title to root path
- Flexing the search layout to accommodate welcome screen
- "Home" page allows discovery; fixes ndlib/planning#263.
- Updating the search results views
- Reordering search result actions
- Site title color adjustments
- Datasets have descriptions not abstracts
- Tidying up attribute listings
