### PR TITLE
Normalizing linking method for classify concern

### DIFF
--- a/app/views/classify_concerns/new.html.erb
+++ b/app/views/classify_concerns/new.html.erb
@@ -13,8 +13,8 @@
         <h3 class="title"><%= klass.human_readable_type %></h3>
         <p class="short-description"><%= klass.human_readable_short_description %></p>
         <%= link_to 'Add New',
-          classify_concerns_path(classify_concern: {"curation_concern_type"=>klass.name}),
-          class: "add-button btn btn-primary #{dom_class(klass, 'add_new')}", method: :post
+          new_polymorphic_path([:curation_concern, klass]),
+          class: "add-button btn btn-primary #{dom_class(klass, 'add_new')}"
         %>
       </li>
     <% end %>

--- a/app/views/shared/_site_actions.html.erb
+++ b/app/views/shared/_site_actions.html.erb
@@ -8,7 +8,13 @@
       <li><strong class="menu-heading item-with-options">Add a Work</strong>
       <ul class="item-options quick-classify">
         <% QuickClassificationQuery.each_for_context(current_user) do |concern| %>
-          <li><%= link_to "New #{concern.human_readable_type}",  polymorphic_path([:curation_concern, concern], action: :new), class: "item-option contextual-quick-classify #{dom_class(concern, 'new').gsub('_', '-')}",       role: 'menuitem' %></li>
+          <li><%= link_to(
+                    "New #{concern.human_readable_type}",
+                    new_polymorphic_path([:curation_concern, concern]),
+                    class: "item-option contextual-quick-classify #{dom_class(concern, 'new').gsub('_', '-')}",
+                    role: 'menuitem'
+              ) %>
+          </li>
         <% end %>
         <li><%= link_to 'More Options', new_classify_concern_path,         class: 'item-option link-to-full-list', role: 'menuitem' %></li>
       </ul>


### PR DESCRIPTION
The classify#create action is preserved for API behavior (i.e. if I
create a classify request it would redirect me to the appropriate
location)
