### PR TITLE
Improve embargo date widget.

### DIFF
--- a/app/assets/javascripts/curate.js
+++ b/app/assets/javascripts/curate.js
@@ -1,8 +1,5 @@
-// This is a manifest file that'll be compiled into application.js, which will include all the files
+// This is a manifest file that'll be compiled into curate.js, which will include all the files
 // listed below.
-//
-// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
-// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
 //
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.
@@ -54,13 +51,9 @@ $(function(){
   $('.link-users').linkUsers();
   $('.proxy-rights').proxyRights();
 
-  // Collapse all of the accordion body elements except the first
-  // $('.accordion-body').each(function(index){
-  //   if(index != 0) {
-  //     $(this).removeClass('in');
-  //   }
-  // });
 
-  $('.datepicker').datepicker({
-    format: 'yyyy-mm-dd' });
+  $('#permissions_display .datepicker').datepicker({
+    format: 'yyyy-mm-dd',
+    startDate: '+1d'
+  });
 });

--- a/app/views/curation_concern/base/_form_permission.html.erb
+++ b/app/views/curation_concern/base/_form_permission.html.erb
@@ -24,7 +24,7 @@
       </label>
       <label class="radio">
         <input type="radio" id="visibility_embargo" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>" <% if curation_concern.open_access_with_embargo_release_date? %> checked="true"<% end %>/>
-        <span class="label label-warning">Open Access with Embargo</span> Treated as <span class="label label-important">Private</span> until <%= f.input :embargo_release_date, wrapper: :inline, input_html: { placeholder: Date.today, class: 'input-small datepicker' } %> then it is <span class="label label-success">Open Access</span>.
+        <span class="label label-warning">Open Access with Embargo</span> Treated as <span class="label label-important">Private</span> until <%= f.input :embargo_release_date, wrapper: :inline, input_html: { placeholder: Date.tomorrow, class: 'input-small datepicker' } %> then it is <span class="label label-success">Open Access</span>.
       </label>
       <label class="radio">
         <input type="radio" id="visibility_ndu" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>" <% if curation_concern.authenticated_only_access? %> checked="true"<% end %> />


### PR DESCRIPTION
Embargo date must be in the future. So give a datepicker that only
allows valid (future) dates.

Fixes ndlib/planning#228
