### PR TITLE
Handling Remote Identifier mixed case

### DIFF
--- a/app/repository_models/curation_concern/doi_assignable.rb
+++ b/app/repository_models/curation_concern/doi_assignable.rb
@@ -34,7 +34,9 @@ module CurationConcern
 
     def request_remote_minting_for(value = doi_assignment_strategy)
       return false unless doi_remote_service.accessor_name.to_s == value.to_s
-      doi_remote_service.mint(self)
+      if doi_remote_service.registered?(self)
+        send("#{doi_remote_service.accessor_name}=", '1')
+      end
     end
 
     def update_identifier_locally(value = doi_assignment_strategy)

--- a/app/views/curation_concern/base/_form_doi.html.erb
+++ b/app/views/curation_concern/base/_form_doi.html.erb
@@ -34,20 +34,20 @@
       <%- remote_service = Hydra::RemoteIdentifier.remote_service(:doi) -%>
       <%- if remote_service.registered?(curation_concern) -%>
         <label class="radio">
-          <input type="radio" name="<%= f.object_name %>[doi_assignment_strategy]" value="<%= remote_service.accessor_name %>" <% if curation_concern.doi_assignment_strategy == remote_service.accessor_name.to_s %> checked="true"<% end %> />
+          <input type="radio" name="<%= f.object_name %>[doi_assignment_strategy]" id="<%= f.object_name %>_doi_assignment_strategy_<%= remote_service.accessor_name %>" value="<%= remote_service.accessor_name %>" <% if curation_concern.doi_assignment_strategy == remote_service.accessor_name.to_s %> checked="true"<% end %> />
           <span class="label-text">
             Yes, I would like to create a <abbr title="Digital Object Identifier">DOI</abbr> for this <%= curation_concern.human_readable_type %>.
           </span>
         </label>
       <%- end -%>
       <label class="radio">
-        <input type="radio" name="<%= f.object_name %>[doi_assignment_strategy]" value="<%= CurationConcern::DoiAssignable::ALREADY_GOT_ONE %>" <% if curation_concern.doi_assignment_strategy == CurationConcern::DoiAssignable::ALREADY_GOT_ONE %> checked="true"<% end %> />
+        <input type="radio" name="<%= f.object_name %>[doi_assignment_strategy]" id="<%= f.object_name %>_doi_assignment_strategy_<%= CurationConcern::DoiAssignable::ALREADY_GOT_ONE %>" value="<%= CurationConcern::DoiAssignable::ALREADY_GOT_ONE %>" <% if curation_concern.doi_assignment_strategy == CurationConcern::DoiAssignable::ALREADY_GOT_ONE %> checked="true"<% end %> />
         <span class="label-text">
           Yes, I already have one that I want to use: <%= f.input :existing_identifier, wrapper: :inline, value: curation_concern.identifier, input_html: { placeholder: "doi:10.5072/FK2FT8XZZ", class: 'input-small' } %>
         </span>
       </label>
       <label class="radio">
-        <input type="radio" name="<%= f.object_name %>[doi_assignment_strategy]" value="<%= CurationConcern::DoiAssignable::NOT_NOW %>" <% if curation_concern.doi_assignment_strategy == CurationConcern::DoiAssignable::NOT_NOW %> checked="true"<% end %> />
+        <input type="radio" name="<%= f.object_name %>[doi_assignment_strategy]" id="<%= f.object_name %>_doi_assignment_strategy_<%= CurationConcern::DoiAssignable::NOT_NOW  %>" value="<%= CurationConcern::DoiAssignable::NOT_NOW %>" <% if curation_concern.doi_assignment_strategy == CurationConcern::DoiAssignable::NOT_NOW %> checked="true"<% end %> />
         <span class="label-text">
           Not now…<em>but maybe later.</em>
         </span>

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -216,6 +216,7 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
     options['Visibility'] ||= 'visibility_restricted'
     options["Button to click"] ||= "Create Generic work" 
     options["Contributors"] ||= "Dante"
+    options["DOI Strategy"] ||= CurationConcern::DoiAssignable::NOT_NOW
     options["Content License"] ||= Sufia.config.cc_licenses.keys.first
 
     # Without accepting agreement
@@ -230,6 +231,10 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
       select(options['Content License'], from: I18n.translate('sufia.field_label.rights'))
 
       fill_in("generic_work_contributors_attributes_0_name", with: options['Contributors'])
+
+      if options['DOI Strategy']
+        choose("generic_work_doi_assignment_strategy_#{options['DOI Strategy']}")
+      end
 
       if options['I Agree']
         check("I have read and accept the contributor license agreement")

--- a/spec/repository_models/curation_concern/doi_assignable_spec.rb
+++ b/spec/repository_models/curation_concern/doi_assignable_spec.rb
@@ -52,8 +52,9 @@ describe CurationConcern::DoiAssignable do
     context 'with request for minting' do
       let(:doi_assignment_strategy) { accessor_name }
 
-      it 'should request a minting' do
-        doi_remote_service.should_receive(:mint).with(subject).and_return(true)
+      it 'should update the remote service accessor so we can remotely mint the DOI' do
+        subject.should_receive("#{accessor_name}=").with('1').and_return(true)
+        doi_remote_service.should_receive(:registered?).with(subject).and_return(true)
         expect {
           subject.send(:apply_doi_assignment_strategy)
         }.to_not change(subject, :identifier).from(nil)


### PR DESCRIPTION
Given that the remote identifiers can sometimes be explicitly set
and other times require a 3rd party API call, I need to make sure
the DOI minting is synchronized.

Closes ndlib/planning#167
