### PR TITLE
Unfreezing keys for factories

### DIFF
--- a/lib/generators/curate/work/templates/factory.rb.erb
+++ b/lib/generators/curate/work/templates/factory.rb.erb
@@ -10,7 +10,7 @@ FactoryGirl.define do
     end
 
     sequence(:title) {|n| "Title #{n}"}
-    rights { Sufia.config.cc_licenses.keys.first }
+    rights { Sufia.config.cc_licenses.keys.first.dup }
     date_uploaded { Date.today }
     date_modified { Date.today }
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -46,7 +46,9 @@ describe CatalogController do
 
       context "when json is requested for autosuggest of related works" do
         let!(:work) { FactoryGirl.create(:generic_work, user: user, title:"All my #{srand}") }
-
+        after do
+          work.destroy
+        end
         it "should return json" do
           xhr :get, :index, format: :json, q: work.title
           json = JSON.parse(response.body)

--- a/spec/factories/articles_factory.rb
+++ b/spec/factories/articles_factory.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     end
     sequence(:title) {|n| "Title #{n}"}
     sequence(:abstract) {|n| "Abstract #{n}"}
-    rights { Sufia.config.cc_licenses.keys.first }
+    rights { Sufia.config.cc_licenses.keys.first.dup }
     date_uploaded { Date.today }
     date_modified { Date.today }
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED

--- a/spec/factories/datasets_factory.rb
+++ b/spec/factories/datasets_factory.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
       user {FactoryGirl.create(:user)}
     end
     sequence(:title) {|n| "Title #{n}"}
-    rights { Sufia.config.cc_licenses.keys.first }
+    rights { Sufia.config.cc_licenses.keys.first.dup }
     date_uploaded { Date.today }
     date_modified { Date.today }
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED

--- a/spec/factories/etds_factory.rb
+++ b/spec/factories/etds_factory.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     end
     sequence(:title) {|n| "Title #{n}"}
     sequence(:abstract) {|n| "Abstract #{n}"}
-    rights { Sufia.config.cc_licenses.keys.first }
+    rights { Sufia.config.cc_licenses.keys.first.dup }
     date_uploaded { Date.today }
     date_modified { Date.today }
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED

--- a/spec/factories/generic_works_factory.rb
+++ b/spec/factories/generic_works_factory.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
       user {FactoryGirl.create(:user)}
     end
     sequence(:title) {|n| "Title #{n}"}
-    rights { Sufia.config.cc_licenses.keys.first }
+    rights { Sufia.config.cc_licenses.keys.first.dup }
     date_uploaded { Date.today }
     date_modified { Date.today }
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED

--- a/spec/factories/images_factory.rb
+++ b/spec/factories/images_factory.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     end
     sequence(:title) {|n| "Title #{n}"}
     sequence(:description) {|n| "Description #{n}"}
-    rights { Sufia.config.cc_licenses.keys.first }
+    rights { Sufia.config.cc_licenses.keys.first.dup }
     date_uploaded { Date.today }
     date_modified { Date.today }
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED

--- a/spec/features/article_spec.rb
+++ b/spec/features/article_spec.rb
@@ -14,7 +14,7 @@ describe 'Creating a article' do
         fill_in "Abstract", with: "My abstract"
         fill_in "Contributor", with: "Test article contributor"
         fill_in "External link", with: "http://www.youtube.com/watch?v=oHg5SJYRHA0"
-        select(Sufia.config.cc_licenses.keys.first, from: I18n.translate('sufia.field_label.rights'))
+        select(Sufia.config.cc_licenses.keys.first.dup, from: I18n.translate('sufia.field_label.rights'))
         check("I have read and accept the contributor license agreement")
         click_button("Create Article")
       end

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -85,7 +85,7 @@ describe "Search for a work" do
       fill_in "Creator", with: user.name
       fill_in "Date created", with: "2013-10-15"
       fill_in "Description", with: "Test description"
-      select(Sufia.config.cc_licenses.keys.first, from: I18n.translate('sufia.field_label.rights'))
+      select(Sufia.config.cc_licenses.keys.first.dup, from: I18n.translate('sufia.field_label.rights'))
       check("I have read and accept the contributor license agreement")
       click_button("Create Image")
     end

--- a/spec/features/dataset_spec.rb
+++ b/spec/features/dataset_spec.rb
@@ -14,7 +14,7 @@ describe 'Creating a dataset' do
         fill_in "Contributor", with: "Test dataset contributor"
         fill_in "Description", with: "This dataset is for testing purposes"
         fill_in "External link", with: "http://www.youtube.com/watch?v=oHg5SJYRHA0"
-        select(Sufia.config.cc_licenses.keys.first, from: I18n.translate('sufia.field_label.rights'))
+        select(Sufia.config.cc_licenses.keys.first.dup, from: I18n.translate('sufia.field_label.rights'))
         check("I have read and accept the contributor license agreement")
         click_button("Create Dataset")
       end

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -217,7 +217,7 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
     options["Button to click"] ||= "Create Generic work" 
     options["Contributors"] ||= "Dante"
     options["DOI Strategy"] ||= CurationConcern::DoiAssignable::NOT_NOW
-    options["Content License"] ||= Sufia.config.cc_licenses.keys.first
+    options["Content License"] ||= Sufia.config.cc_licenses.keys.first.dup
 
     # Without accepting agreement
     within('#new_generic_work') do

--- a/spec/features/etd_spec.rb
+++ b/spec/features/etd_spec.rb
@@ -16,7 +16,7 @@ describe 'Creating an etd' do
       fill_in "Advisor", with: "Marcy Holmes"
       fill_in "Subject", with: "Paleoethnography"
       fill_in "Date created", with: "2013 October 4"
-      select(Sufia.config.cc_licenses.keys.first, from: I18n.translate('sufia.field_label.rights'))
+      select(Sufia.config.cc_licenses.keys.first.dup, from: I18n.translate('sufia.field_label.rights'))
       check("I have read and accept the contributor license agreement")
       click_button("Create Etd")
     end

--- a/spec/features/generic_work_spec.rb
+++ b/spec/features/generic_work_spec.rb
@@ -12,7 +12,7 @@ describe 'Creating a generic work' do
       within '#new_generic_work' do
         fill_in "Title", with: "My title"
         fill_in "External link", with: "http://www.youtube.com/watch?v=oHg5SJYRHA0"
-        select(Sufia.config.cc_licenses.keys.first, from: I18n.translate('sufia.field_label.rights'))
+        select(Sufia.config.cc_licenses.keys.first.dup, from: I18n.translate('sufia.field_label.rights'))
         check("I have read and accept the contributor license agreement")
         click_button("Create Generic work")
       end

--- a/spec/features/image_spec.rb
+++ b/spec/features/image_spec.rb
@@ -13,7 +13,7 @@ describe 'Creating an image' do
       fill_in "Creator", with: "Test image creator"
       fill_in "Date created", with: "2013-10-04"
       fill_in "Description", with: "Test description"
-      select(Sufia.config.cc_licenses.keys.first, from: I18n.translate('sufia.field_label.rights'))
+      select(Sufia.config.cc_licenses.keys.first.dup, from: I18n.translate('sufia.field_label.rights'))
       check("I have read and accept the contributor license agreement")
       click_button("Create Image")
     end


### PR DESCRIPTION
The upstream RDF was attempting to encode a frozen value. For the
record `{'a' => 'b'}.keys.first` is frozen.
