### PR TITLE
Improving generator controller code

### DIFF
--- a/lib/generators/curate/work/templates/controller_spec.rb.erb
+++ b/lib/generators/curate/work/templates/controller_spec.rb.erb
@@ -3,5 +3,5 @@
 require 'spec_helper'
 
 describe CurationConcern::<%= class_name.pluralize %>Controller do
-  include_examples 'is_a_curation_concern_controller', <%= class_name %>, actions: :all
+  it_behaves_like 'is_a_curation_concern_controller', <%= class_name %>, actions: :all
 end


### PR DESCRIPTION
By switching to it_behaves_like, the rspec failures are more friendly
for troubleshooting.

[skip ci]
