### PR TITLE
Extracting Accept Contributor Agreement behavior

### DIFF
--- a/app/assets/javascripts/curate.js
+++ b/app/assets/javascripts/curate.js
@@ -31,6 +31,7 @@
 //= require curate/link_users
 //= require curate/proxy_rights
 //= require curate/facet_mine
+//= require curate/accept_contributor_agreement
 //= require handlebars
 
 $(function(){

--- a/app/assets/javascripts/curate/accept_contributor_agreement.js
+++ b/app/assets/javascripts/curate/accept_contributor_agreement.js
@@ -1,0 +1,15 @@
+$(function(){
+  $("a[rel=popover]").popover({ html : true, trigger: "hover" });
+  $("a[rel=popover]").click(function() { return false;});
+
+  $('#accept_contributor_agreement').each(function(){
+    $.fn.disableAgreeButton = function(element) {
+      var $submit_button = $('input.require-contributor-agreement');
+      $submit_button.prop("disabled", !element.checked);
+    };
+    $.fn.disableAgreeButton(this);
+    $(this).on('change', function(){
+      $.fn.disableAgreeButton(this);
+    });
+  });
+});

--- a/app/views/curation_concern/base/_form_contributor_agreement.html.erb
+++ b/app/views/curation_concern/base/_form_contributor_agreement.html.erb
@@ -13,12 +13,13 @@
     </div>
 
     <div class="span12 accept-contributor-agreement">
-      <%= label_tag contributor_agreement.param_key, class: 'checkbox' do %>
+      <%= label_tag contributor_agreement.param_key, class: 'checkbox', for:  'accept_contributor_agreement' do %>
         <%= check_box_tag(
             contributor_agreement.param_key,
             contributor_agreement.acceptance_value,
             contributor_agreement.param_value,
-            required: :required
+            required: :required,
+            id: 'accept_contributor_agreement'
           )
         %>
         I have read and accept the contributor license agreement


### PR DESCRIPTION
This JS behavior is ported from CurateND. Its purpose is to disable
the form submit button unless the user agrees to the terms.
