### PR TITLE
Requiring publisher validation for DOI minting

### DIFF
--- a/lib/generators/curate/work/templates/model_spec.rb.erb
+++ b/lib/generators/curate/work/templates/model_spec.rb.erb
@@ -11,7 +11,6 @@ describe <%= class_name %> do
   it_behaves_like 'with_access_rights'
   it_behaves_like 'is_embargoable'
   it_behaves_like 'has_dc_metadata'
-  it_behaves_like 'doi_assignable'
   <%- if register_doi? -%>
   it_behaves_like 'remotely_identified', :doi
   <%- end -%>

--- a/spec/repository_models/curation_concern/remotely_identified_by_doi_spec.rb
+++ b/spec/repository_models/curation_concern/remotely_identified_by_doi_spec.rb
@@ -1,3 +1,4 @@
+
 require 'spec_helper'
 
 describe CurationConcern::RemotelyIdentifiedByDoi do
@@ -27,7 +28,6 @@ describe CurationConcern::RemotelyIdentifiedByDoi do
     it { should respond_to(:existing_identifier=) }
     it { should respond_to(:doi_assignment_strategy=) }
     it { should respond_to(:doi_assignment_strategy) }
-    it_behaves_like 'doi_assignable'
 
   end
 

--- a/spec/repository_models/generic_work_spec.rb
+++ b/spec/repository_models/generic_work_spec.rb
@@ -8,7 +8,7 @@ describe GenericWork do
   it_behaves_like 'is_embargoable'
   it_behaves_like 'has_dc_metadata'
   it_behaves_like 'has_common_solr_fields'
-  it_behaves_like 'doi_assignable'
+  it_behaves_like 'remotely_identified', :doi
 
   it { should have_unique_field(:available) }
   it { should have_unique_field(:human_readable_type) }

--- a/spec/support/shared/doi_assignable.rb
+++ b/spec/support/shared/doi_assignable.rb
@@ -1,9 +1,0 @@
-shared_examples 'doi_assignable' do
-  it { should respond_to(:identifier) }
-  it { should respond_to(:identifier=) }
-  it { should respond_to(:existing_identifier) }
-  it { should respond_to(:existing_identifier=) }
-  it { should respond_to(:doi_assignment_strategy=) }
-  it { should respond_to(:doi_assignment_strategy) }
-  it { subject.class.included_modules.should include CurationConcern::RemotelyIdentifiedByDoi::Attributes }
-end

--- a/spec/support/shared/shared_examples_remotely_identified.rb
+++ b/spec/support/shared/shared_examples_remotely_identified.rb
@@ -1,13 +1,26 @@
 shared_examples 'remotely_identified' do |remote_service_name|
   context "by #{remote_service_name}" do
-    subject { FactoryGirl.create(described_class.name.underscore, publisher: 'An Interesting Chap!') }
-    it 'mints!' do
-      expect {
-        Hydra::RemoteIdentifier.mint(remote_service_name, subject)
-      }.to change(subject, :identifier).from(nil)
-    end
+    subject { FactoryGirl.create(described_class.name.underscore, attributes) }
     after(:each) {
       subject.destroy
     }
+    context 'with valid attributes' do
+      let(:attributes) { { publisher: 'An Interesting Chap!' } }
+      it 'mints!' do
+        expect {
+          Hydra::RemoteIdentifier.mint(remote_service_name, subject)
+        }.to change(subject, :identifier).from(nil)
+      end
+    end
+    if remote_service_name == :doi
+      context 'with invalid attributes' do
+        let(:attributes) { { publisher: [] } }
+        it 'fails validation' do
+          subject.should_receive(:remote_doi_assignment_strategy?).and_return(true)
+          expect(subject).to_not be_valid
+          expect(subject.errors[:publisher]).to eq(["is required for remote DOI minting"])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
When we are remotely minting DOIs, the publisher is a required
attribute. Otherwise it is not required.

Closes #242
