### PR TITLE
Preventing downstream autorun interactions

### DIFF
--- a/lib/curate/spec_support.rb
+++ b/lib/curate/spec_support.rb
@@ -5,10 +5,6 @@ spec_directory = File.expand_path('../../../spec', __FILE__)
 require "rails/test_help"
 require 'rspec/rails'
 require 'rspec-html-matchers'
-
-# Prevent double spec runs under Zeus
-require 'rspec/autorun' unless ENV['RUNNING_VIA_ZEUS']
-
 require 'factory_girl'
 require 'capybara/poltergeist'
 Dir["#{spec_directory}/factories/**/*.rb"].each { |f| require f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,11 @@ end
 
 require File.expand_path("../internal/config/environment.rb",  __FILE__)
 
+# Prevent double spec runs under Zeus
+require 'rspec/autorun' unless ENV['RUNNING_VIA_ZEUS']
+
 require File.expand_path('../spec_patch', __FILE__)
+
 require 'curate/spec_support'
 require 'database_cleaner'
 


### PR DESCRIPTION
Given that other dependent applications are using spec_support
Don't include the autorun option as that can interfere with behavior
(in particular Zeus).

http://stackoverflow.com/questions/14030561/zeus-rspec-fails-include-required-files-but-rspec-alone-does-fine
