### PR TITLE
Adding context to Related Works search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -337,9 +337,12 @@ class CatalogController < ApplicationController
     end
 
     def serialize_work_from_solr(solr_doc)
-       {
-        pid: solr_doc["id"], title: solr_doc["desc_metadata__title_tesim"].first
-       }
+      title = solr_doc["desc_metadata__title_tesim"].first
+      title << " (#{solr_doc["human_readable_type_tesim"].first})" if solr_doc["human_readable_type_tesim"].present?
+      {
+        pid: solr_doc["id"],
+        title: title
+      }
     end
 
     # show only files with edit permissions in lib/hydra/access_controls_enforcement.rb apply_gated_discovery

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -55,7 +55,7 @@ describe CatalogController do
         json = JSON.parse(response.body)
         # Grab the doc corresponding to work and inspect the json
         work_json = json["docs"].first
-        work_json.should == {"pid"=>work.pid, "title"=>work.title}
+        work_json.should == {"pid"=>work.pid, "title"=> "#{work.title} (#{work.human_readable_type})"}
       end
     end
 


### PR DESCRIPTION
Searching for Related Works should include a context (i.e. Human
Readable Type)
