### PR TITLE
Removing hidden edit link. Fixes ndlib/planning#303.

### DIFF
--- a/app/views/curation_concern/articles/_attributes.html.erb
+++ b/app/views/curation_concern/articles/_attributes.html.erb
@@ -14,9 +14,7 @@
   <tr>
     <th>Access Rights</th>
     <td>
-      <ul class="tabular">
-        <li class="attribute permission"><%= link_to_edit_permissions(curation_concern) %></li>
-      </ul>
+      <%= permission_badge_for(curation_concern) %>
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>

--- a/app/views/curation_concern/base/_related_files.html.erb
+++ b/app/views/curation_concern/base/_related_files.html.erb
@@ -21,7 +21,7 @@
         </td>
         <td class="attribute filename"><%= link_to(generic_file_link_name(generic_file), curation_concern_generic_file_path(generic_file)) %></td>
         <td class="attribute date_uploaded"><%= generic_file.date_uploaded %></td>
-        <td class="attribute permission"><%= link_to_edit_permissions(generic_file) %></td>
+        <td class="attribute permission"><%= permission_badge_for(generic_file) %></td>
         <td>
           <%- if with_actions -%>
             <%- if can?(:edit, generic_file) -%>

--- a/app/views/curation_concern/documents/_attributes.html.erb
+++ b/app/views/curation_concern/documents/_attributes.html.erb
@@ -5,7 +5,6 @@
   </thead>
   <tbody>
   <%= curation_concern_attribute_to_html(curation_concern, :description, 'Abstract') %>
-
   <%= render partial: 'contributors_attribute' %>
   <%= curation_concern_attribute_to_html(curation_concern, :type, "Document Type") %>
   <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
@@ -16,9 +15,7 @@
   <tr>
     <th>Access Rights</th>
     <td>
-      <ul class="tabular">
-        <li class="attribute permission"><%= link_to_edit_permissions(curation_concern) %></li>
-      </ul>
+      <%= permission_badge_for(curation_concern) %>
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>

--- a/app/views/curation_concern/etds/_attributes.html.erb
+++ b/app/views/curation_concern/etds/_attributes.html.erb
@@ -12,9 +12,7 @@
   <tr>
     <th>Access Rights</th>
     <td>
-      <ul class="tabular">
-        <li class="attribute permission"><%= link_to_edit_permissions(curation_concern) %></li>
-      </ul>
+      <%= permission_badge_for(curation_concern) %>
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>

--- a/app/views/curation_concern/generic_works/_attributes.html.erb
+++ b/app/views/curation_concern/generic_works/_attributes.html.erb
@@ -5,7 +5,6 @@
   </thead>
   <tbody>
   <%= curation_concern_attribute_to_html(curation_concern, :description, 'Abstract') %>
-
   <%= render partial: 'contributors_attribute' %>
   <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>
   <%= curation_concern_attribute_to_html(curation_concern, :publisher, "Publisher") %>
@@ -15,9 +14,7 @@
   <tr>
     <th>Access Rights</th>
     <td>
-      <ul class="tabular">
-        <li class="attribute permission"><%= link_to_edit_permissions(curation_concern) %></li>
-      </ul>
+      <%= permission_badge_for(curation_concern) %>
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>

--- a/app/views/curation_concern/images/_attributes.html.erb
+++ b/app/views/curation_concern/images/_attributes.html.erb
@@ -13,9 +13,7 @@
   <tr>
     <th>Access Rights</th>
     <td>
-      <ul class="tabular">
-        <li class="attribute permission"><%= link_to_edit_permissions(curation_concern) %></li>
-      </ul>
+      <%= permission_badge_for(curation_concern) %>
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>


### PR DESCRIPTION
NOTE: #link_to_edit_permissions is no longer being used.
However, all the tests are for #link_to_edit_permissions not #permission_badge_for.
