### PR TITLE
Freeze Rails to 4.0.0

### DIFF
--- a/curate.gemspec
+++ b/curate.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.licenses = ['APACHE2']
 
-  s.add_dependency "rails", "~> 4.0.0"
+  s.add_dependency "rails", "4.0.0"
   s.add_dependency "breach-mitigation-rails"
   s.add_dependency 'sufia-models', '~>3.4.0.rc4'
 #  s.add_dependency 'hydra', '6.1.0.rc8'


### PR DESCRIPTION
Rails 4.0.1 introduced some incompatabilities in ActionPack

We can fix this a bit later.
