### PR TITLE
Ensuring user login creates person and profile

### DIFF
--- a/app/models/curate/user_behavior/with_associated_person.rb
+++ b/app/models/curate/user_behavior/with_associated_person.rb
@@ -9,8 +9,8 @@ module Curate
 
         person_attributes_not_already_on_base.each do |attribute_name|
           delegate attribute_name, to: :person
-          delegate :profile, to: :person
         end
+        delegate :profile, to: :person, allow_nil: true
       end
 
       def reload
@@ -22,7 +22,7 @@ module Curate
         @person ||= if self.repository_id
                       Person.find(self.repository_id)
                     else
-                      Person.new
+                      Person.new(name: name)
                     end
       end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -40,6 +40,26 @@ describe Account do
     let(:alternate_email) { 'somewhere@not-here.com'}
     subject { FactoryGirl.create(:account) }
 
+    context 'without person or profile' do
+
+      let(:password) { 'password' }
+      let(:user) { FactoryGirl.create(:user, password: password, password_confirmation: password) }
+      let(:attributes) { {current_password: password} }
+      subject { Account.new(user) }
+
+      it 'should create a person and profile' do
+        expect(user.profile).to be_nil
+        expect(user.person).to_not be_persisted
+
+        subject.update_with_password(attributes)
+
+        user.reload
+        expect(user.person).to be_persisted
+        expect(user.profile).to be_persisted
+      end
+
+    end
+
     describe 'with valid attributes' do
       it 'should update the user' do
         expect {
@@ -136,7 +156,7 @@ describe Account do
 
     it 'has a default title for the profile' do
       subject.name.should be_nil
-      subject.profile.title.should == 'Profile'
+      subject.profile.title.should == user.name
     end
   end
 


### PR DESCRIPTION
CurateND has an existing case in which we have users, some with
corresponding person instances and some without, but none with
profiles.

This patch makes sure that when a user logs in that a person instance
is persisted (if applicable) and a profile instance is persisted
(if applicable).
