### PR TITLE
Improving collection management interface

### DIFF
--- a/app/assets/javascripts/curate.js
+++ b/app/assets/javascripts/curate.js
@@ -57,4 +57,6 @@ $(function(){
     format: 'yyyy-mm-dd',
     startDate: '+1d'
   });
+
+  $('.remove-member').on('ajax:success', function(){window.location.href = window.location.href});
 });

--- a/app/assets/stylesheets/layout/positioning.css.scss
+++ b/app/assets/stylesheets/layout/positioning.css.scss
@@ -58,11 +58,19 @@ dl.stacked {
   }
 }
 
-.main-header {
-  border-bottom: 1px solid $grayLighter;
+.main-header,
+.page-actions {
   margin-bottom: 30px;
   margin-top: 20px;
   padding-bottom: 9px;
+}
+
+.main-header {
+  border-bottom: 1px solid $grayLighter;
+}
+
+.page-actions {
+  text-align:right;
 }
 
 .search > .row > .main-header {

--- a/app/assets/stylesheets/modules.scss
+++ b/app/assets/stylesheets/modules.scss
@@ -2,6 +2,7 @@
 @import 'modules/accessibility';
 @import 'modules/attributes';
 @import 'modules/classify_work';
+@import 'modules/collections';
 @import 'modules/emphatic_action_area';
 @import 'modules/forms';
 @import 'modules/multi_value_fields';

--- a/app/assets/stylesheets/modules/collections.css.scss
+++ b/app/assets/stylesheets/modules/collections.css.scss
@@ -1,0 +1,30 @@
+.collection-listing {
+  list-style-type:none;
+  margin:0 0 1em;
+
+  .with-controls {
+    line-height:2;
+  }
+}
+
+.collection-member {
+  padding-bottom:.5em;
+  position:relative;
+}
+
+.collection-member-actions {
+  position:absolute;
+  top:0;
+  right:0;
+}
+
+.collection-section-heading {
+}
+
+.collection-section-description {
+  margin-bottom:10px;
+}
+
+.collection-section-heading + .collection-section-description {
+  margin-top:-10px;
+}

--- a/app/views/curate/collections/show.html.erb
+++ b/app/views/curate/collections/show.html.erb
@@ -2,7 +2,15 @@
 <% content_for :page_header do %>
   <h1> <%= @collection.title %> </h1>
 <% end %>
-<p> <%= @collection.description %> </p>
+<% if can? :edit, @collection %>
+  <% content_for :page_actions do %>
+    <%= link_to 'Edit', edit_collection_path(@collection), class: 'btn' %>
+  <% end %>
+<% end %>
+<div class="collection-description">
+  <%= @collection.description %>
+</div>
+
 <div id="documents" class="clear">
   <%= list_items_in_collection(@collection) %>
 </div>

--- a/app/views/curate/people/show.html.erb
+++ b/app/views/curate/people/show.html.erb
@@ -36,7 +36,11 @@
 
   <div id="person_profile" class="span9">
     <% if profile_has_contents?(@person) %>
-      <h3><%= "Selected Works of #{@person.name}" %> </h3>
+      <% if @person.profile.title == @person.name %>
+        <h3><%= "Selected Works of #{@person.name}" %></h3>
+      <% else %>
+        <h3><%= @person.profile.title %></h3>
+      <% end %>
       <p><%= @person.profile.description %> </p>
 
       <div id="documents" class="clear">

--- a/app/views/curation_concern/base/_collections.html.erb
+++ b/app/views/curation_concern/base/_collections.html.erb
@@ -5,14 +5,15 @@
   </caption>
   <thead>
     <tr>
-      <th>Collection Title</th>
+      <th>Collections Featuring this <%= curation_concern.human_readable_type %></th>
     </tr>
   </thead>
   <tbody>
     <% curation_concern.collections.each do |collection| %>
       <tr class="collection attributes">
-        <td class="attribute title"><%= link_to collection.title, collection %></td>
-        <td><%= link_to(raw('<i class="icon-white icon-minus"></i>'), remove_member_collections_path(id: collection.to_param, item_id: curation_concern.pid, redirect_to: request.original_url), id: curation_concern.pid, class: 'btn btn-danger remove', title: 'Remove Item from Collection' ) if can? :edit, curation_concern  %></td>
+        <%= content_tag :td, class: 'attribute title', data: { noid: collection.noid } do %>
+          <%= link_to collection.title, collection %>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/layouts/curate_nd.html.erb
+++ b/app/views/layouts/curate_nd.html.erb
@@ -36,9 +36,18 @@
   <div id="main" role="main" class="container <%= yield(:page_class) if content_for?(:page_class)%>">
   <% if content_for?(:page_header) %>
     <div class="row">
-      <div class="span12 main-header">
+    <% if content_for?(:page_actions) %>
+      <div class="span10 main-header ">
         <%= yield(:page_header) %>
       </div>
+      <div class="span2 page-actions">
+        <%= yield(:page_actions) %>
+      </div>
+    <% else %>
+      <div class="span12 main-header ">
+        <%= yield(:page_header) %>
+      </div>
+    <% end %>
     </div>
   <% end %>
 

--- a/lib/curate/rails/routes.rb
+++ b/lib/curate/rails/routes.rb
@@ -7,7 +7,7 @@ module ActionDispatch::Routing
           collection do
             get :add_member_form
             put :add_member
-            get :remove_member
+            put :remove_member
           end
         end
         resources 'people', only: [:show, :index] do

--- a/spec/features/collections_show_spec.rb
+++ b/spec/features/collections_show_spec.rb
@@ -4,20 +4,18 @@ describe "Collections show view: " do
   let!(:user) { FactoryGirl.create(:user) }
   let!(:bilbo) { FactoryGirl.create(:person, name: 'Bilbo') }
   let!(:frodo) { FactoryGirl.create(:person, name: 'Frodo') }
-  let!(:work1) { FactoryGirl.create(:generic_work, user: user, contributors: [bilbo, frodo], title: 'Work 1') }
-  let!(:collection) { FactoryGirl.create(:public_collection, user: user, title: 'Collected Stuff', members: [work1]) }
+  let!(:article) { FactoryGirl.create(:generic_work, user: user, contributors: [bilbo, frodo], title: 'An Article') }
+  let!(:collection) { FactoryGirl.create(:public_collection, user: user, title: 'Collected Stuff', members: [article]) }
 
-  context "For logged in members: " do
+  context "For logged in members:" do
     it "remove an item from the collection" do
       login_as(user)
       visit collection_path(collection.pid)
-      page.should have_css("a[id$='#{work1.pid}']")
-      page.should have_css("a[title$='Remove Item from Collection']")
-      click_on 'Remove Item from Collection'
+      page.should have_css(".collection-member[data-noid='#{article.noid}']")
+      click_on "remove-#{article.noid}"
 
       visit collection_path(collection.pid)
-      page.should_not have_css("a[id$='#{work1.pid}']")
-      page.should_not have_css("a[title$='Remove Item from Collection']")
+      page.should_not have_css(".collection-member[data-noid='#{article.noid}']")
     end
   end
 

--- a/spec/features/remove_items_from_collection_spec.rb
+++ b/spec/features/remove_items_from_collection_spec.rb
@@ -1,22 +1,19 @@
 require 'spec_helper'
 
-describe "GenericWork show view: " do
-  let!(:user) { FactoryGirl.create(:user) }
-  let!(:work1) { FactoryGirl.create(:generic_work, user: user, title: 'Work 1') }
-  let!(:collection) { FactoryGirl.create(:public_collection, user: user, title: 'Collected Stuff', members: [work1]) }
+describe "Remove member from collection" do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:article) { FactoryGirl.create(:generic_work, user: user, title: 'A Scholarly Paper') }
+  let(:collection) { FactoryGirl.create(:public_collection, user: user, title: 'Articles of Great Import', members: [article]) }
 
-  context "For logged in members: " do
-    it "remove this item from the collection" do
-      collection.members << work1
-      collection.save!
+  context "If a user alredy has a collection with content in it" do
+    it "should be easy to remove a member from a collection" do
       login_as(user)
-      visit curation_concern_generic_work_path(work1.pid)
-      page.should have_css("a[href$='/collections/#{collection.pid}']")
-      click_on 'Remove Item from Collection'
+      visit collection_path(collection)
+      page.should have_css("[data-noid='#{article.noid}']")
+      click_on "remove-#{article.noid}"
 
-      visit curation_concern_generic_work_path(work1.pid)
-      page.should_not have_css("a[href$='/collections/#{collection.pid}']")
-      page.should_not have_css("a[title$='Remove Item from Collection']")
+      visit curation_concern_generic_work_path(article.noid)
+      page.should_not have_css("[data-noid='#{collection.noid}']")
     end
   end
 end

--- a/spec/views/curation_concern/base/_collection.html.erb_spec.rb
+++ b/spec/views/curation_concern/base/_collection.html.erb_spec.rb
@@ -6,7 +6,6 @@ describe 'curation_concern/base/_collection.html.erb' do
   let(:display_name) { 'My Display Name'}
   let(:person) { FactoryGirl.create(:person_with_user) }
   let(:user) { person.user }
-  #let(:curation_concern) { FactoryGirl.create(:generic_work, user: user, title: 'Work 1') }
   let(:collection) { FactoryGirl.create(:collection, user: user, title: 'Collection 1') }
 
   context 'logged in' do
@@ -20,7 +19,6 @@ describe 'curation_concern/base/_collection.html.erb' do
 
     it 'lists all the collections the work is added to' do
       expect(rendered).to include("Collection 1")
-      expect(rendered).to include("Remove Item from Collection")
       expect(rendered).to include("Add to Collection")
     end
   end
@@ -36,7 +34,6 @@ describe 'curation_concern/base/_collection.html.erb' do
 
     it 'lists all the collections the work is added to' do
       expect(rendered).to include("Collection 1")
-      expect(rendered).not_to include("Remove Item from Collection")
       expect(rendered).not_to include("Add to Collection")
     end
   end


### PR DESCRIPTION
Tidying up collection contents management.

You should be able to remove items based on your privileges on the
collection -- not your privileges on the contained item.

Allow collection edit controls to be in the page header

Allow AJAX removal of collection members

Fixes ndlib/planning#332

View test hooks and refactoring

Data attributes to the rescue. In the future we could use these for
JavaScript behavior too.

Let people rename their profile collection.

This may be a bad idea.

Only let items be removed from collections on the collection page.
