### PR TITLE
Normalizing email and preferred email

### DIFF
--- a/app/controllers/concerns/curate_controller.rb
+++ b/app/controllers/concerns/curate_controller.rb
@@ -72,7 +72,7 @@ module CurateController
 
   def configure_permitted_parameters
     full_list = [:email, :password, :password_confirmation, :current_password,
-                 :name, :preferred_email, :alternate_email,
+                 :name, :email, :alternate_email,
                  :date_of_birth, :gender, :title,
                  :campus_phone_number, :alternate_phone_number,
                  :personal_webpage, :blog, :files]

--- a/app/repository_datastreams/person_metadata_datastream.rb
+++ b/app/repository_datastreams/person_metadata_datastream.rb
@@ -41,7 +41,7 @@ class PersonMetadataDatastream < ActiveFedora::NtriplesRDFDatastream
       index.as :stored_searchable
     end
 
-    map.preferred_email(to: "account#preferred_email", in: RDF::QualifiedFOAF) do |index|
+    map.email(to: "account#preferred_email", in: RDF::QualifiedFOAF) do |index|
       index.as :stored_searchable
     end
   end

--- a/app/repository_models/person.rb
+++ b/app/repository_models/person.rb
@@ -20,7 +20,7 @@ class Person < ActiveFedora::Base
   attribute :name,
     datastream: :descMetadata, multiple: false
 
-  attribute :preferred_email,
+  attribute :email,
     datastream: :descMetadata, multiple: false
 
   attribute :alternate_email,
@@ -89,7 +89,7 @@ class Person < ActiveFedora::Base
 
   def gravatar_link
     return @gravatar_link unless @gravatar_link.blank?
-    @gravatar_link = File.join(GRAVATAR_URL, email_hash(self.preferred_email || user.email), "?s=300")
+    @gravatar_link = File.join(GRAVATAR_URL, email_hash(self.email || user.email), "?s=300")
     @gravatar_link += "&d=" + File.join(GRAVATAR_URL, email_hash(self.alternate_email), "?s=300") unless self.alternate_email.blank?
     @gravatar_link
   end

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -31,7 +31,7 @@
         <p><em>Currently waiting confirmation for: <%= resource.unconfirmed_email %></em></p>
       <% end %>
 
-      <%= f.input :email,           as: :email, required: true %>
+      <%= f.input :email, as: :email, required: true %>
       <%= f.input :alternate_email, as: :email %>
 
       <%= f.input :campus_phone_number,    as: :tel %>


### PR DESCRIPTION
Assuming that a user giving an email address means "This is my
preferred email"

To consider, Devise has an email field which is used for
authentication if using a localized auth scheme (instead of LDAP or
CAS).
