### PR TITLE
Refactoring Profile to its own class

### DIFF
--- a/app/controllers/curate/collections_controller.rb
+++ b/app/controllers/curate/collections_controller.rb
@@ -63,7 +63,7 @@ class Curate::CollectionsController < ApplicationController
   end
 
   def remove_member
-    @collection = Collection.find(params[:id])
+    @collection = ActiveFedora::Base.find(params[:id], cast: true)
     item = ActiveFedora::Base.find(params[:item_id], cast:true)
     @collection.remove_member(item)
     redirect_to params.fetch(:redirect_to) { collection_path(params[:id]) }
@@ -82,7 +82,7 @@ class Curate::CollectionsController < ApplicationController
     id = id_from_params(:collection_id)
     id ||= id_from_params(:profile_collection_id)
     return nil unless id
-    @collection = Collection.find(id)
+    @collection = ActiveFedora::Base.find(id, cast: true)
     authorize! :update, @collection
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -23,7 +23,7 @@ class Account
   delegate :person, to: :user
 
   def profile
-    @profile ||= person.profile || person.build_profile(title: profile_title, resource_type: 'Profile')
+    @profile ||= person.profile || person.build_profile(title: profile_title)
   end
 
   class_attribute :person_attribute_names

--- a/app/repository_models/collection.rb
+++ b/app/repository_models/collection.rb
@@ -1,63 +1,8 @@
 class Collection < ActiveFedora::Base
-  include Hydra::Collection
-  include Hydra::AccessControls::Permissions
-  include Hydra::AccessControls::WithAccessRight
-  include Sufia::Noid
+  include CurationConcern::CollectionModel
+  include Hydra::Collections::Collectible
 
-  has_many :associated_persons, property: :has_profile, class_name: 'Person'
-
-  has_attributes :resource_type, datastream: :descMetadata, multiple: false
-
-  # Causes resource_type to be set in the metadata
-  before_create :human_readable_type
-
-  # Reads from resource_type attribute. 
-  # Defaults to "Collection", but can be set to something else.
-  # Profiles are marked with resource_type of "Profile" when they're created by the associated Person object
-  # This is used to populate the Object Type Facet
-  def human_readable_type
-    self.resource_type ||= "Collection"
+  def can_be_member_of_collection?(collection)
+    collection == self ? false : true
   end
-
-  def add_member(collectible)
-    return false unless collectible
-    self.members << collectible
-    self.save
-  end
-
-  def remove_member(collectible)
-    return false unless self.members.include?(collectible)
-    self.members.delete(collectible)
-    self.save
-  end
-
-  def is_profile?
-    !associated_persons.empty?
-  end
-
-  def to_s
-    self.title.nil? ? self.inspect : self.title
-  end
-
-  def to_solr(solr_doc={}, opts={})
-    super
-    Solrizer.set_field(solr_doc, 'generic_type', 'Collection', :facetable)
-    solr_doc
-  end
-
-  # ------------------------------------------------
-  # overriding method from active-fedora:
-  # lib/active_fedora/semantic_node.rb
-  #
-  # The purpose of this override is to ensure that
-  # a collection cannot contain itself.
-  #
-  # TODO:  After active-fedora 7.0 is released, this
-  # logic can be moved into a before_add callback.
-  # ------------------------------------------------
-  def add_relationship(predicate, target, literal=false)
-    return if self == target
-    super
-  end
-
 end

--- a/app/repository_models/curation_concern/collection_model.rb
+++ b/app/repository_models/curation_concern/collection_model.rb
@@ -1,0 +1,63 @@
+module CurationConcern
+  module CollectionModel
+    extend ActiveSupport::Concern
+
+    included do
+      include Hydra::Collection
+      include Hydra::AccessControls::Permissions
+      include Hydra::AccessControls::WithAccessRight
+      include Sufia::Noid
+      include CurationConcern::HumanReadableType
+      include InstanceMethods # Because methods are defined before included; which means Hydra::Collection's remove_member is showing up first
+    end
+
+    module InstanceMethods
+
+      def add_member(collectible)
+        if can_add_to_members?(collectible)
+          self.members << collectible
+          self.save
+        end
+      end
+
+      def remove_member(collectible)
+        return false unless self.members.include?(collectible)
+        self.members.delete(collectible)
+        self.save
+      end
+
+      def to_s
+        self.title.present? ? title : inspect
+      end
+
+      def to_solr(solr_doc={}, opts={})
+        super
+        Solrizer.set_field(solr_doc, 'generic_type', human_readable_type, :facetable)
+        solr_doc
+      end
+
+      # ------------------------------------------------
+      # overriding method from active-fedora:
+      # lib/active_fedora/semantic_node.rb
+      #
+      # The purpose of this override is to ensure that
+      # a collection cannot contain itself.
+      #
+      # TODO:  After active-fedora 7.0 is released, this
+      # logic can be moved into a before_add callback.
+      # ------------------------------------------------
+      def add_relationship(predicate, target, literal=false)
+        return if self == target
+        super
+      end
+
+      private
+      def can_add_to_members?(collectible)
+        collectible.can_be_member_of_collection?(self)
+      rescue NoMethodError
+        false
+      end
+
+    end
+  end
+end

--- a/app/repository_models/curation_concern/human_readable_type.rb
+++ b/app/repository_models/curation_concern/human_readable_type.rb
@@ -1,0 +1,23 @@
+module CurationConcern
+  module HumanReadableType
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def human_readable_type
+        name.demodulize.titleize
+      end
+    end
+
+    def human_readable_type
+      self.class.human_readable_type
+    end
+
+    def to_solr(solr_doc={}, opts={})
+      super(solr_doc, opts)
+      solr_doc[Solrizer.solr_name('human_readable_type',:facetable)] = human_readable_type
+      solr_doc[Solrizer.solr_name('human_readable_type', :stored_searchable)] = human_readable_type
+      return solr_doc
+    end
+
+  end
+end

--- a/app/repository_models/person.rb
+++ b/app/repository_models/person.rb
@@ -12,7 +12,7 @@ class Person < ActiveFedora::Base
   has_file_datastream :name => "medium"
   has_file_datastream :name => "thumbnail"
 
-  belongs_to :profile, property: :has_profile, class_name: 'Collection'
+  belongs_to :profile, property: :has_profile, class_name: 'Profile'
 
   attr_accessor :mime_type
   makes_derivatives :generate_derivatives

--- a/app/repository_models/profile.rb
+++ b/app/repository_models/profile.rb
@@ -1,0 +1,20 @@
+class Profile < ActiveFedora::Base
+  include CurationConcern::CollectionModel
+
+  has_many :associated_persons, property: :has_profile, class_name: 'Person'
+
+  has_attributes :resource_type, datastream: :descMetadata, multiple: false
+
+
+  # Causes resource_type to be set in the metadata
+  before_create :human_readable_type
+
+  # Reads from resource_type attribute.
+  # Defaults to "Collection", but can be set to something else.
+  # Profiles are marked with resource_type of "Profile" when they're created by the associated Person object
+  # This is used to populate the Object Type Facet
+  def human_readable_type
+    self.resource_type ||= "Profile"
+  end
+
+end

--- a/app/views/catalog/_add_to_collection_gui.html.erb
+++ b/app/views/catalog/_add_to_collection_gui.html.erb
@@ -1,6 +1,6 @@
 <% unless @collection_options.empty? && @profile_collection_options.empty? %>
   <% modal_id = "#{document.noid}-modal" %>
-  <div class="modal fade" id=<%= modal_id %>>
+  <div class="modal fade" id="<%= modal_id %>">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">

--- a/app/views/curation_concern/base/_add_to_collection_gui.html.erb
+++ b/app/views/curation_concern/base/_add_to_collection_gui.html.erb
@@ -1,6 +1,6 @@
 <% if current_user %>
   <% modal_id = "#{collectible.noid}-modal" %>
-  <div class="modal fade" id=<%= modal_id %>>
+  <div class="modal fade" id="<%= modal_id %>">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">

--- a/app/views/profiles/_profile.html.erb
+++ b/app/views/profiles/_profile.html.erb
@@ -1,0 +1,54 @@
+<%# This is a search result view %>
+<% noid = profile.noid %>
+<li id="document_<%= noid %>" class="search-result">
+
+  <div class="row-fluid">
+
+    <div class="span2 list-number">
+      <%= document_counter_with_offset( profile_counter ) %>
+      <%= render :partial => 'catalog/_index_partials/type_display', locals: {document: profile} %>
+    </div>
+
+    <div class="span6">
+      <% solr_doc = profile.inner_object.solr_doc %>
+      <%# Minimize Fedora hits by using solr_doc rather than document %>
+      <%= link_to render_index_field_value(document: solr_doc, field: 'desc_metadata__title_tesim'), profile, :id => "src_copy_link_#{noid}" %>
+    </div>
+
+    <div class="span4">
+      <% if current_user %>
+        <%= render partial: 'add_to_collection_gui', locals: { document: profile } %>
+
+        <%= link_to(
+          raw('<i class="icon-pencil icon-large"></i>'),
+          edit_collection_path(profile),
+            :class=> 'itemicon itemedit btn pull-right',
+            :title => 'Edit Profile'
+          ) if can? :edit, profile %>
+      <% end -%>
+    </div>
+
+  </div>
+
+  <div class="row-fluid">
+
+    <div class="span2">
+      <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: profile} %>
+    </div>
+
+    <div class="span10">
+      <dl class="attribute-list">
+        <% if solr_doc.has?('desc_metadata__description_tesim') %>
+          <dt>Description:</dt>
+          <dd><%= truncate(render_index_field_value(document: solr_doc, field: 'desc_metadata__description_tesim'), length: 150) %></dd>
+        <% end %>
+
+        <% if solr_doc.has?('edit_access_person_ssim') %>
+          <dt>Owner:</dt>
+          <dd><%= render_index_field_value(document: solr_doc, field: 'edit_access_person_ssim') %></dd>
+        <% end %>
+    </div>
+
+  </div>
+
+</li>

--- a/lib/curate/rails/routes.rb
+++ b/lib/curate/rails/routes.rb
@@ -3,7 +3,7 @@ module ActionDispatch::Routing
 
     def curate_for(opts={})
       scope module: 'curate' do
-        resources 'collections' do
+        resources 'collections', 'profiles', controller: 'collections' do
           collection do
             get :add_member_form
             put :add_member

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -112,7 +112,7 @@ describe Account do
               subject.save
             }.to change(User, :count).by(1)
           }.to change(Person, :count).by(1)
-        }.to change(Collection, :count).by(1)
+        }.to change(Profile, :count).by(1)
 
         user = subject.user.reload
         expect(user.name).to eq(expected_name)
@@ -144,7 +144,7 @@ describe Account do
               subject.save
             }.to_not change(User, :count)
           }.to_not change(Person, :count)
-        }.to_not change(Collection, :count)
+        }.to_not change(Profile, :count)
         expect(subject.errors).to_not be_empty
       end
     end

--- a/spec/repository_models/collection_spec.rb
+++ b/spec/repository_models/collection_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe Collection do
   let(:reloaded_subject) { Collection.find(subject.pid) }
 
+  it 'can be part of a collection' do
+    expect(subject.can_be_member_of_collection?(double)).to be_true
+  end
+
+
   it 'can contain another collection' do
     another_collection = FactoryGirl.create(:collection)
     subject.members << another_collection
@@ -38,39 +43,16 @@ describe Collection do
   end
 
   describe "to_solr on a saved object" do
-    before {subject.save(validate: false)}
     let(:solr_doc) {subject.to_solr}
+    it "should have a generic_type_sim" do
+     solr_doc['generic_type_sim'].should == ['Collection']
+    end
 
-    describe "when profile is set" do
-      before { subject.resource_type = 'Profile' }
-      it "should have field" do
-       solr_doc['desc_metadata__resource_type_sim'].should == [subject.human_readable_type]
-       solr_doc['desc_metadata__resource_type_tesim'].should == [subject.human_readable_type]
-       solr_doc['generic_type_sim'].should == ['Collection']
-      end
-    end
-    describe "when profile isn't set" do
-      it "should have field" do
-       solr_doc['desc_metadata__resource_type_sim'].should == [subject.human_readable_type]
-       solr_doc['desc_metadata__resource_type_tesim'].should == [subject.human_readable_type]
-       solr_doc['generic_type_sim'].should == ['Collection']
-      end
-    end
   end
 
   describe '#human_readable_type' do
-    context "when profile is set" do
-      it "indicates profile" do
-        subject.resource_type = 'Profile'
-        subject.save(validate: false)
-        subject.human_readable_type.should == 'Profile'
-      end
-    end
-
-    context "when profile isn't set" do
-      it "indicates collection" do
-        subject.human_readable_type.should == 'Collection'
-      end
+    it "indicates collection" do
+      subject.human_readable_type.should == 'Collection'
     end
   end
 

--- a/spec/repository_models/curation_concern/collection_model_spec.rb
+++ b/spec/repository_models/curation_concern/collection_model_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe CurationConcern::CollectionModel do
+  let(:klass) {
+    Class.new(ActiveFedora::Base) {
+      include CurationConcern::CollectionModel
+      def members; @members ||= []; end
+      def save; true; end
+    }
+  }
+
+  context '.add_member' do
+    let(:collectible?) { nil }
+    let(:proposed_collectible) { double }
+    subject { klass.new }
+    before(:each) {
+      proposed_collectible.stub(:can_be_member_of_collection?).with(subject).and_return(collectible?)
+    }
+
+    context 'with itself' do
+      it 'does not add it to the collection\'s members' do
+        expect {
+          subject.add_member(subject)
+        }.to_not change{ subject.members.size }
+      end
+    end
+
+    context 'with a non-collectible object' do
+      let(:collectible?) { false }
+      it 'does not add it to the collection\'s members' do
+        expect {
+          subject.add_member(proposed_collectible)
+        }.to_not change{ subject.members.size }
+      end
+    end
+
+    context 'with a collectible object' do
+      let(:collectible?) { true }
+      it 'adds it to the collection\'s members' do
+        expect {
+          subject.add_member(proposed_collectible)
+        }.to change{ subject.members.size }.by(1)
+      end
+    end
+  end
+end

--- a/spec/repository_models/curation_concern/human_readable_type_spec.rb
+++ b/spec/repository_models/curation_concern/human_readable_type_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe CurationConcern::HumanReadableType do
+  let(:klass) {
+    Class.new {
+      def self.name; 'HelloWorld';end
+      include CurationConcern::HumanReadableType
+    }
+  }
+
+  it 'should have .human_readable_type' do
+    expect(klass.human_readable_type).to eq('Hello World')
+  end
+  it 'should have #human_readable_type' do
+     expect(klass.new.human_readable_type).to eq('Hello World')
+  end
+end

--- a/spec/repository_models/person_spec.rb
+++ b/spec/repository_models/person_spec.rb
@@ -6,7 +6,7 @@ describe Person do
     subject { FactoryGirl.create(:person_with_user) }
     its(:user) { should be_instance_of User }
     it '#profile' do
-      expect(subject.profile).to be_instance_of Collection
+      expect(subject.profile).to be_instance_of Profile
       expect(subject.profile.depositor).to eq subject.user.to_s
       expect(subject.profile.title).to_not be_nil
       expect(subject.profile.read_groups).to eq [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC]

--- a/spec/repository_models/profile_spec.rb
+++ b/spec/repository_models/profile_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Profile do
+  subject { Profile.new }
+  it 'can never be part of a collection' do
+    expect {
+      subject.can_be_member_of_collection?
+    }.to raise_error(NoMethodError)
+  end
+end

--- a/spec/support/shared/shared_examples_is_a_curation_concern_model.rb
+++ b/spec/support/shared/shared_examples_is_a_curation_concern_model.rb
@@ -1,8 +1,16 @@
-shared_examples 'is_a_curation_concern_model' do 
+shared_examples 'is_a_curation_concern_model' do
   CurationConcern::FactoryHelpers.load_factories_for(self, described_class)
 
   it 'is registered for classification' do
     expect(Curate.configuration.registered_curation_concern_types).to include(described_class.name)
+  end
+
+  describe 'collectibility' do
+    subject { FactoryGirl.build(default_work_factory_name) }
+    let(:collection) { double }
+    it '#can_be_member_of_collection?' do
+      expect(subject.can_be_member_of_collection?(collection)).to eq(true)
+    end
   end
 
   describe 'its test support factories', factory_verification: true do


### PR DESCRIPTION
Instead of marking Profile as type of Collection, it is instead
being setup as something which can have collectables. The
ProfileSection will also need to be extracted as it is presently
a type of Collection.

Adding membership questions/answers. By using double delegation we can
make sure to instantiate both the collection and the member and allow
the member to answer whether it can be collected by the collection.

Adding Collections as Collectible.

Closes to #262
