### PR TITLE
Renaming User#display_name to User#name

### DIFF
--- a/app/models/curate/user_behavior/base.rb
+++ b/app/models/curate/user_behavior/base.rb
@@ -2,9 +2,7 @@ module Curate
   module UserBehavior
     module Base
       extend ActiveSupport::Concern
-      included do
-        alias_attribute :name, :display_name
-      end
+
       def agree_to_terms_of_service!
         update_column(:agreed_to_terms_of_service, true)
       end
@@ -17,6 +15,9 @@ module Curate
         # override
       end
 
+      def name
+        read_attribute(:name) || user_key
+      end
     end
   end
 end

--- a/app/views/curation_concern/base/_on_behalf_of.html.erb
+++ b/app/views/curation_concern/base/_on_behalf_of.html.erb
@@ -1,6 +1,6 @@
 <% unless current_user.can_make_deposits_for.empty? %>
   <div class="controls" id="delegate-actions">
     <%= f.label :owner, 'On Behalf of' %>
-    <%= f.select :owner, options_from_collection_for_select(current_user.can_make_deposits_for, 'user_key', 'display_name'), prompt: "Yourself" %>
+    <%= f.select :owner, options_from_collection_for_select(current_user.can_make_deposits_for, 'user_key', 'name'), prompt: "Yourself" %>
   </div>
 <% end %>

--- a/app/views/shared/_site_actions.html.erb
+++ b/app/views/shared/_site_actions.html.erb
@@ -27,7 +27,7 @@
   </div>
   <div class="btn-group my-actions">
     <a class="btn btn-primary dropdown-toggle user-display-name" data-toggle="dropdown" href="#">
-      <%= current_user.display_name.blank? ? 'Me' : current_user.display_name %>
+      <%= current_user.name.blank? ? 'Me' : current_user.name %>
     <span class="caret"></span>
     </a>
     <ul class="dropdown-menu" data-no-turbolink="true">

--- a/db/migrate/20131112155553_change_display_name_to_name.rb
+++ b/db/migrate/20131112155553_change_display_name_to_name.rb
@@ -1,0 +1,6 @@
+class ChangeDisplayNameToName < ActiveRecord::Migration
+  def change
+    rename_column(:users, :display_name, :name)
+    add_index(:users, :name)
+  end
+end

--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -101,7 +101,7 @@ This generator makes the following changes to your application:
   end
 
   def inject_curate_user
-    inject_into_class 'app/models/user.rb', 'User' do
+    inject_into_file 'app/models/user.rb', after: /include Sufia\:\:User.*$/ do
       "\n  include Curate::UserBehavior\n"
     end
   end

--- a/spec/features/adding_section_to_profile.rb
+++ b/spec/features/adding_section_to_profile.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Adding a section to a Profile: ' do
 
   context 'logged in user' do
-    let(:account) { FactoryGirl.create(:account, display_name: 'Bilbo Baggins') }
+    let(:account) { FactoryGirl.create(:account, name: 'Bilbo Baggins') }
     let(:user) { account.user }
     before { login_as(user) }
   

--- a/spec/features/person_profile_spec.rb
+++ b/spec/features/person_profile_spec.rb
@@ -4,7 +4,7 @@ describe 'Profile for a Person: ' do
 
   context 'logged in user' do
     let(:password) { FactoryGirl.attributes_for(:user).fetch(:password) }
-    let(:account) { FactoryGirl.create(:account, display_name: 'Iron Man') }
+    let(:account) { FactoryGirl.create(:account, name: 'Iron Man') }
     let(:user) { account.user }
     let(:person) { account.person }
     before { login_as(user) }
@@ -54,7 +54,7 @@ describe 'Profile for a Person: ' do
 
   context 'A person when logged in' do
     let(:password) { FactoryGirl.attributes_for(:user).fetch(:password) }
-    let(:account) { FactoryGirl.create(:account, display_name: 'Iron Man') }
+    let(:account) { FactoryGirl.create(:account, name: 'Iron Man') }
     let(:user) { account.user }
     let(:person) { account.person }
     let(:image_file){ Rails.root.join('../fixtures/files/image.png') }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -155,7 +155,7 @@ describe Account do
     subject { Account.new(user) }
 
     it 'has a default title for the profile' do
-      subject.name.should be_nil
+      subject.name.should == user.name
       subject.profile.title.should == user.name
     end
   end

--- a/spec/views/curation_concern/base/_add_to_collection_gui.html.erb_spec.rb
+++ b/spec/views/curation_concern/base/_add_to_collection_gui.html.erb_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe 'curation_concern/base/_add_to_collection_gui' do
   let(:curation_concern) { FactoryGirl.create(:generic_work) }
-  let(:current_user) { double(display_name: display_name, person: person) }
-  let(:display_name) { 'My Display Name'}
+  let(:current_user) { double(name: name, person: person) }
+  let(:name) { 'My Display Name'}
   let(:person) { FactoryGirl.create(:person_with_user) }
   let(:user) { person.user }
 

--- a/spec/views/curation_concern/base/_collection.html.erb_spec.rb
+++ b/spec/views/curation_concern/base/_collection.html.erb_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe 'curation_concern/base/_collection.html.erb' do
   let(:curation_concern) { FactoryGirl.create(:generic_work, user: user) }
-  let(:current_user) { double(display_name: display_name, person: person) }
-  let(:display_name) { 'My Display Name'}
+  let(:current_user) { double(name: name, person: person) }
+  let(:name) { 'My Display Name'}
   let(:person) { FactoryGirl.create(:person_with_user) }
   let(:user) { person.user }
   let(:collection) { FactoryGirl.create(:collection, user: user, title: 'Collection 1') }

--- a/spec/views/shared/_site_actions.html.erb_spec.rb
+++ b/spec/views/shared/_site_actions.html.erb_spec.rb
@@ -20,8 +20,8 @@ describe 'shared/_site_actions.html.erb' do
 
   context 'logged in' do
     let(:person) { double }
-    let(:display_name) { 'My Display Name' }
-    let(:current_user) { double(display_name: display_name, person: person) }
+    let(:name) { 'My Display Name' }
+    let(:current_user) { double(name: name, person: person) }
     it 'renders a link to create a new user session' do
       expect(rendered).to_not have_login_section
       expect(rendered).to have_add_content_section do
@@ -34,7 +34,7 @@ describe 'shared/_site_actions.html.erb' do
       end
       expect(rendered).to have_my_actions_section do
         with_tag '.my-actions' do
-          with_tag 'a.user-display-name', text: /#{display_name}/
+          with_tag 'a.user-display-name', text: /#{name}/
           with_tag '.dropdown-menu' do
             with_tag 'a.my-works'
             with_tag 'a.my-collections', with: { href: collections_path}


### PR DESCRIPTION
It is rather confusing having Person#name and User#display_name and
attempting to keep them synchronized.

Factoring to a singular User#name.

This also revealed that the include order of our User models is rather
jumbled up. Namely we should have a User model as:

```
class User
  include Hydra::User
  include Sufia::User
  include Curate::UserBehavior
end
```

Closes #291
