### PR TITLE
Allowing the content type listing page to flex properly

### DIFF
--- a/app/assets/stylesheets/modules/classify_work.css.scss
+++ b/app/assets/stylesheets/modules/classify_work.css.scss
@@ -1,13 +1,55 @@
+@import 'global-variables';
+
+/* Aligning content types by leveraging text-align:justify
+  http://www.barrelny.com/blog/text-align-justify-and-rwd/
+*/
+
 .classify-work {
   list-style-type:none;
+  text-align: justify;
+  font-size: 0.1px;
+  margin:0 0 2em;
 }
 
+/* 2 Column */
 .classify-work > .work-type {
   border:1px solid #EEE;
-  margin-bottom:2em;
+  box-sizing:border-box;
+  display:inline-block;
+  font-size:$baseFontSize;
   padding:.5em;
   position:relative;
   text-align:center;
+  margin:1em 4%;
+  width:40%;
+}
+
+/* 3 Column */
+@media (min-width: 600px){
+  .classify-work > .work-type {
+    margin:1em 2%;
+    width:29%;
+  }
+}
+
+/* 4 Column */
+@media (min-width: 1000px){
+  .classify-work > .work-type {
+    margin:1em 2%;
+    width:21%;
+  }
+}
+
+/* 5 Column */
+@media (min-width: 1200px){
+  .classify-work > .work-type {
+    margin:1em 1%;
+    width:18%;
+  }
+}
+
+.classify-work > .placeholder {
+  border-color:transparent;
 }
 
 .classify-work > .upcoming {

--- a/app/views/classify_concerns/new.html.erb
+++ b/app/views/classify_concerns/new.html.erb
@@ -9,7 +9,7 @@
 <div class="row-fluid">
   <ul class="classify-work">
     <% classify_concern.all_curation_concern_classes.each do |klass| %>
-      <li class="span2 work-type">
+      <li class="work-type">
         <h3 class="title"><%= klass.human_readable_type %></h3>
         <p class="short-description"><%= klass.human_readable_short_description %></p>
         <%= link_to 'Add New',
@@ -19,7 +19,7 @@
       </li>
     <% end %>
     <% classify_concern.upcoming_concerns.each do |name, description| %>
-      <li class="span2 upcoming work-type">
+      <li class="upcoming work-type">
         <h3 class="title"><%= name %></h3>
         <p class="short-description"><%= description %></p>
         <%= link_to 'Add New',
@@ -28,5 +28,8 @@
         %>
       </li>
     <%- end -%>
+    <li class="work-type placeholder" aria-hidden="true"></li>
+    <li class="work-type placeholder" aria-hidden="true"></li>
+    <li class="work-type placeholder" aria-hidden="true"></li>
   </ul>
 </div>


### PR DESCRIPTION
More than one row can now be displayed properly.
The content type width and number per row flexes based on viewport size.
