### PR TITLE
Small batch of refinements before user testing begins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp/*
 .sass-cache
 .idea/
 coverage
+spec/fixtures/cassettes/*

--- a/app/assets/stylesheets/modules/collections.css.scss
+++ b/app/assets/stylesheets/modules/collections.css.scss
@@ -13,9 +13,21 @@
 }
 
 .collection-member-actions {
+  float:right;
+  min-width:12em;
   position:absolute;
-  top:0;
   right:0;
+  top:0;
+
+  .btn {
+    margin-right:.3em;
+  }
+
+  .btn,
+  .remove-member {
+    float:right;
+    margin-bottom:0;
+  }
 }
 
 .collection-section-heading {

--- a/app/assets/stylesheets/modules/site_actions.css.scss
+++ b/app/assets/stylesheets/modules/site_actions.css.scss
@@ -2,6 +2,11 @@
   .dropdown-menu {
     text-align:left;
   }
+
+  // Overriding default boostrap behavior
+  .btn-group + .btn-group {
+    margin-left:0;
+  }
 }
 
 .dropdown-menu {

--- a/app/assets/stylesheets/style/typography.css.scss
+++ b/app/assets/stylesheets/style/typography.css.scss
@@ -35,7 +35,7 @@
 #site-title h1 {
   font-family:$serifFontFamily;
   font-size:2.4em;
-  line-height:1.3em;
+  line-height:1.2em;
   text-align:center;
 }
 

--- a/app/helpers/curate/collections_helper.rb
+++ b/app/helpers/curate/collections_helper.rb
@@ -79,11 +79,29 @@ module Curate::CollectionsHelper
     end
   end
 
-  def collection_member_actions(collection, work)
+  def collection_member_actions(collection, member)
     content_tag :span, class: 'collection-member-actions' do
-      button_to remove_member_collections_path(id: collection.to_param, item_id: work.pid), data: {confirm: 'Are you sure you want to remove this item from the collection?'}, method: :put, id: "remove-#{work.noid}", class: 'btn btn-danger', form_class: 'remove-member', remote: true do
-        raw('<i class="icon-white icon-minus"></i> Remove')
+      if member.respond_to?(:members)
+        markup = actions_for_member(collection, member)
+        markup << actions_for_profile_section(collection, member)
+      else
+        actions_for_member(collection, member)
       end
+    end
+  end
+
+  # NOTE: Profile Sections and Collections are being rendered the same way.
+  def actions_for_profile_section(collection, member)
+    if can? :edit, member
+      link_to edit_collection_path(id: member.to_param), class: 'btn' do
+        raw('<i class="icon-pencil"></i> Edit')
+      end
+    end
+  end
+
+  def actions_for_member(collection, member)
+    button_to remove_member_collections_path(id: collection.to_param, item_id: member.pid), data: { confirm: 'Are you sure you want to remove this item from the collection?' }, method: :put, id: "remove-#{member.noid}", class: 'btn btn-danger', form_class: 'remove-member', remote: true do
+      raw('<i class="icon-white icon-minus"></i> Remove')
     end
   end
 

--- a/app/views/shared/_site_actions.html.erb
+++ b/app/views/shared/_site_actions.html.erb
@@ -21,8 +21,6 @@
       </li>
       <li class="divider"></li>
       <li><%= link_to 'Add a Collection',  new_collection_path, class: 'menu-heading new-collection', role: 'menuitem' %></li>
-      <li class="divider"></li>
-      <li><%= link_to 'Add a Section to my Profile', new_collection_path(add_to_profile: true), class: 'menu-heading new-collection', role: 'menuitem' %></li>
     </ul>
   </div>
   <div class="btn-group my-actions">

--- a/spec/views/shared/_site_actions.html.erb_spec.rb
+++ b/spec/views/shared/_site_actions.html.erb_spec.rb
@@ -29,7 +29,6 @@ describe 'shared/_site_actions.html.erb' do
           with_tag 'a.link-to-full-list', with: { href: new_classify_concern_path }
           with_tag 'a.contextual-quick-classify', minimum: 3
           with_tag 'a.new-collection', with: { href: new_collection_path }, text: 'Add a Collection'
-          with_tag 'a.new-collection', with: { href: new_collection_path(add_to_profile: true) }, text: 'Add a Section to my Profile'
         end
       end
       expect(rendered).to have_my_actions_section do


### PR DESCRIPTION
Ignore cassettes

Minor adjustment to header whitespace

Allow editing profile sections from your profile

Fix button spacing in site-actions

Demoting the add a profile section action
  You can still do this while viewing your profile

Profile edit actions
