### PR TITLE
Added a representative_image partial

### DIFF
--- a/app/views/curation_concern/base/_representative_image.html.erb
+++ b/app/views/curation_concern/base/_representative_image.html.erb
@@ -1,0 +1,6 @@
+<%# Override this partial if you want a more complex preview of the object (e.g. Deep zoom viewer, or a larger image preview) %>
+<%- if work.representative.present? -%>
+  <%= image_tag download_path(work.representative, datastream_id: 'thumbnail'), class: 'representative_image'  %>
+<%- else -%>
+  <%= image_tag 'curate/nope.png', class: "canonical-image" %>
+<%- end -%>

--- a/app/views/curation_concern/base/show.html.erb
+++ b/app/views/curation_concern/base/show.html.erb
@@ -2,7 +2,8 @@
 <% content_for :page_header do %>
   <h1><%= curation_concern %> <span class="human_readable_type">(<%= curation_concern.human_readable_type %>)</span></h1>
 <% end %>
-<%= render partial: 'thumbnail', locals: {thumbnail: curation_concern, dom_class_name: 'representative_image'} %>
+<%= render partial: 'representative_image', locals: {work: curation_concern} %>
+
 <%= render 'attributes', curation_concern: curation_concern %>
 <%= render 'doi', curation_concern: curation_concern %>
 


### PR DESCRIPTION
Previously this was using the thumbnail partial. The representative
image should be able to be something different than the thumbnail if
provided by the application. In our application we are putting a
larger preview image here.
