### PR TITLE
Removing some GenericFile constraints

### DIFF
--- a/app/models/curate/content_version.rb
+++ b/app/models/curate/content_version.rb
@@ -1,0 +1,23 @@
+module Curate
+  class ContentVersion
+    class Null
+      def initialize(content)
+      end
+      def created_on; 'unknown'; end
+      def committer_name; 'unknown'; end
+      def formatted_created_on(*args); 'unknown'; end
+      def version_id; 'unknown'; end
+    end
+
+    attr_reader :version_id, :created_on, :committer_name
+    def initialize(content, version_structure)
+      @created_on = version_structure.dsCreateDate
+      @version_id = version_structure.versionID
+      @committer_name = content.version_committer(version_structure)
+    end
+
+    def formatted_created_on(format = :long_ordinal )
+      created_on.localtime.to_formatted_s(format)
+    end
+  end
+end

--- a/app/views/curation_concern/generic_files/versions.html.erb
+++ b/app/views/curation_concern/generic_files/versions.html.erb
@@ -1,20 +1,20 @@
 <%= simple_form_for curation_concern, :url => rollback_curation_concern_generic_file_path(curation_concern), method: :put do |f| %>
-      <% if curation_concern.persisted? %>
-        <fieldset>
-          <legend> Versioning</legend>
-          <%#
-            TODO - Cleanup up this violation of Law of Demeter
-            curation_concern.versions should yield a version object
-            * version#created_on
-            * version#committer
-            * version#number
-          %>
-          <%= "Current version uploaded on #{curation_concern.content.latest_version.dsCreateDate.localtime.to_formatted_s(:long_ordinal)} [by #{curation_concern.content.version_committer(curation_concern.content.latest_version)}]"%>
-          <%= f.input :version , label: "Restore Previous Version from" do %>
-            <%= f.select :version, curation_concern.versions.map { |version| ["Restore from #{version.dsCreateDate.localtime.to_formatted_s(:long_ordinal)} [ by #{curation_concern.content.version_committer(version)}]", version.versionID, { class: curation_concern.content.version_committer(version) }] }, include_blank: true %>
-          <% end %>
-        </fieldset>
-      <%- end -%>
+  <% if curation_concern.persisted? %>
+    <fieldset>
+      <legend> Versioning</legend>
+      <%#
+        TODO - Cleanup up this violation of Law of Demeter
+        curation_concern.versions should yield a version object
+        * version#created_on
+        * version#committer
+        * version#number
+      %>
+      <%= "Current version uploaded on #{curation_concern.latest_version.formatted_created_on} [by #{curation_concern.latest_version.committer_name}]"%>
+      <%= f.input :version , label: "Restore Previous Version from" do %>
+        <%= f.select :version, curation_concern.versions.map { |version| ["Restore from #{version.formatted_created_on} [ by #{version.committer_name}]", version.version_id, { class: version.committer_name }] }, include_blank: true %>
+      <% end %>
+    </fieldset>
+  <%- end -%>
 
   <div class="row">
     <div class="span12 form-actions">

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -7,7 +7,7 @@ describe DownloadsController do
     let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
     let(:image_file) { File.open(Rails.root.join('../fixtures/files/image.png')) }
     let(:generic_file) {
-      FactoryGirl.create_generic_file(:generic_work, user) {|g|
+      FactoryGirl.create_generic_file(:generic_work, user, curate_fixture_file_upload('files/image.png', 'image/png', false)) {|g|
         g.visibility = visibility
       }
     }

--- a/spec/factories/create_generic_file.rb
+++ b/spec/factories/create_generic_file.rb
@@ -12,21 +12,22 @@ def FactoryGirl.create_generic_file(container_factory_name_or_object, user, file
 
   generic_file.visibility ||= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
 
-  file ||= Rack::Test::UploadedFile.new(__FILE__, 'text/plain', false)
-  generic_file.file ||= file
 
   Sufia::GenericFile::Actions.create_metadata(generic_file, user, curation_concern.pid) do |gf|
     gf.batch = curation_concern
     gf.visibility = (generic_file.visibility)
   end
 
-  Sufia::GenericFile::Actions.create_content(
-    generic_file,
-    file,
-    file.original_filename,
-    'content',
-    user
-  )
-
+  if file
+    file ||= Rack::Test::UploadedFile.new(__FILE__, 'text/plain', false)
+    generic_file.file ||= file
+    Sufia::GenericFile::Actions.create_content(
+      generic_file,
+      file,
+      file.original_filename,
+      'content',
+      user
+    )
+  end
   return generic_file
 end

--- a/spec/models/curate/content_version_spec.rb
+++ b/spec/models/curate/content_version_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+module Curate
+  describe ContentVersion do
+    let(:content) { double }
+    let(:created_on) { Time.now }
+    let(:version_id) { 'content.1'}
+    let(:committer_name) { 'darryl' }
+    let(:raw_version) { double(dsCreateDate: created_on, versionID: version_id) }
+    subject { described_class.new(content, raw_version) }
+
+    before(:each) do
+      content.stub(:version_committer).with(raw_version).and_return(committer_name)
+    end
+    its(:created_on) { should eq(created_on) }
+    its(:committer_name) { should eq(committer_name) }
+    its(:version_id) { should eq version_id }
+    its(:formatted_created_on) { should eq created_on.localtime.to_formatted_s(:long_ordinal)}
+  end
+  describe ContentVersion::Null do
+    subject { described_class.new(double)}
+    its(:created_on) { should eq 'unknown'}
+    its(:committer_name) { should eq 'unknown'}
+    its(:version_id) { should eq 'unknown'}
+    its(:formatted_created_on) { should eq 'unknown'}
+  end
+end

--- a/spec/repository_models/generic_file_spec.rb
+++ b/spec/repository_models/generic_file_spec.rb
@@ -6,7 +6,6 @@ describe GenericFile do
   it_behaves_like 'with_access_rights'
   it_behaves_like 'is_embargoable'
 
-  it { should respond_to(:versions) }
   it { should respond_to(:human_readable_type) }
   it { should respond_to(:current_version_id) }
   it { should respond_to(:file=) }
@@ -43,6 +42,14 @@ describe GenericFile do
 
   it 'has file_name as its title to display' do
     expect(persisted_generic_file.to_s).to eq(File.basename(__FILE__))
+  end
+
+  context '#latest_version' do
+    subject { described_class.new.latest_version }
+    it { should respond_to :created_on }
+    it { should respond_to :committer_name }
+    it { should respond_to :formatted_created_on }
+    it { should respond_to :version_id }
   end
 
 end


### PR DESCRIPTION
Instead of requiring files to always be uploaded, remove those
constraints.

Also factoring a Curate::ContentVersion value object
