### PR TITLE
Refactoring Contributor association generation

### DIFF
--- a/app/repository_models/curation_concern/model.rb
+++ b/app/repository_models/curation_concern/model.rb
@@ -18,6 +18,10 @@ module CurationConcern
       { pid: pid, title: title, model: self.class.to_s, curation_concern_type: human_readable_type }
     end
 
+    def as_rdf_object
+      RDF::URI.new(internal_uri)
+    end
+
     def to_solr(solr_doc={}, opts={})
       super(solr_doc, opts)
       index_collection_pids(solr_doc)

--- a/lib/contributors_association.rb
+++ b/lib/contributors_association.rb
@@ -42,16 +42,15 @@ class ContributorsAssociation #< ActiveFedora::Associations::Association TODO wh
 
 
   def delete record
-    owner.send(field_name).delete(RDF::URI.new(record.internal_uri))
+    owner.send(field_name).delete(record.as_rdf_object)
     load_target
   end
 
   protected
 
     def insert_record(record)
-      object = RDF::URI.new(record.internal_uri)
       predicate = owner.config_for_term_or_uri(field_name).predicate
-      owner.graph.insert([owner.rdf_subject, predicate, object ])
+      owner.graph.insert([owner.rdf_subject, predicate, record.as_rdf_object ])
       owner.reset_child_cache!
       @target << record
     end

--- a/spec/support/shared/shared_examples_is_a_curation_concern_model.rb
+++ b/spec/support/shared/shared_examples_is_a_curation_concern_model.rb
@@ -5,7 +5,14 @@ shared_examples 'is_a_curation_concern_model' do
     expect(Curate.configuration.registered_curation_concern_types).to include(described_class.name)
   end
 
-  describe 'collectibility' do
+  context 'behavior' do
+    subject { FactoryGirl.build(default_work_factory_name) }
+    it 'can be cast as an RDF object' do
+      expect(subject.as_rdf_object).to be_kind_of RDF::URI
+    end
+  end
+
+  context 'collectibility' do
     subject { FactoryGirl.build(default_work_factory_name) }
     let(:collection) { double }
     it '#can_be_member_of_collection?' do
@@ -13,7 +20,7 @@ shared_examples 'is_a_curation_concern_model' do
     end
   end
 
-  describe 'its test support factories', factory_verification: true do
+  context 'its test support factories', factory_verification: true do
     it {
       expect {
         FactoryGirl.create(default_work_factory_name)


### PR DESCRIPTION
Instead of assuming the record should be cast as an RDF::URI, let the
record determine how it will be referenced
