### PR TITLE
Removing LinkedResource from Catalog

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -360,6 +360,7 @@ class CatalogController < ApplicationController
       solr_parameters[:fq] << "-has_model_ssim:\"info:fedora/afmodel:GenericFile\""
       solr_parameters[:fq] << "-has_model_ssim:\"info:fedora/afmodel:Profile\""
       solr_parameters[:fq] << "-has_model_ssim:\"info:fedora/afmodel:ProfileSection\""
+      solr_parameters[:fq] << "-has_model_ssim:\"info:fedora/afmodel:LinkedResource\""
       return solr_parameters
     end
 


### PR DESCRIPTION
Given that we are excluding GenericFile from the catalog#index
And LinkedResources are analogous to GenericFile
Then LinkedResource should not be in the catalog#index
