### PR TITLE
Fixing instance variable behavior

### DIFF
--- a/app/views/catalog/_add_to_collection_gui.html.erb
+++ b/app/views/catalog/_add_to_collection_gui.html.erb
@@ -1,4 +1,4 @@
-<% unless @collection_options.empty? && available_profiles.blank? %>
+<% if @collection_options.present? || available_profiles.present? %>
   <% modal_id = "#{document.noid}-modal" %>
   <div class="modal fade" id="<%= modal_id %>">
     <div class="modal-dialog">

--- a/app/views/curate/collections/_form_to_add_member.html.erb
+++ b/app/views/curate/collections/_form_to_add_member.html.erb
@@ -7,7 +7,7 @@
     <div class="control-group collection_id">
       <div class="controls">
         <% options = '<option selected="true" disabled="disabled">Make a Selection</option>'.html_safe %>
-        <%- if (collection = @collection_options.reject {|n| n == collectible}).any? -%>
+        <%- if (collection = (@collection_options || [] ).reject {|n| n == collectible}).any? -%>
           <% options << '<optgroup label="Your Collections">'.html_safe %>
           <% options << options_from_collection_for_select(collection, "pid", "title") %>
           <% options << '</optgroup>'.html_safe %>


### PR DESCRIPTION
Given that an instance variable may not be set in the controller
This should be gracefully handled in the view by asking .present?
instead of .empty?

nil.empty? raises a NoMethodError
nil.present? == false

[].empty? == true
[].present? == false

Also need to ensure that when we reject the collectible we actually
have an array

[skip ci]
