### PR TITLE
Expanding Rails 4.0.x support

### DIFF
--- a/app/controllers/curate/collections_controller.rb
+++ b/app/controllers/curate/collections_controller.rb
@@ -114,7 +114,7 @@ class Curate::CollectionsController < ApplicationController
     add_to_profile
     if @collection.is_a?(ProfileSection)
       respond_to do |format|
-        format.html { redirect_to person_path(current_user.person), notice: "#{@collection.human_readable_type} was successfully created." }
+        format.html { redirect_to user_profile_path, notice: "#{@collection.human_readable_type} was successfully created." }
         format.json { render json: @collection, status: :created, location: @collection }
       end
     else

--- a/app/controllers/curate/user_profiles_controller.rb
+++ b/app/controllers/curate/user_profiles_controller.rb
@@ -9,4 +9,5 @@ class Curate::UserProfilesController < ApplicationController
       redirect_to edit_user_registration_path
     end
   end
+
 end

--- a/app/models/curate/user_behavior/base.rb
+++ b/app/models/curate/user_behavior/base.rb
@@ -3,6 +3,14 @@ module Curate
     module Base
       extend ActiveSupport::Concern
 
+      def repository_noid
+        Sufia::Noid.noidify(repository_id)
+      end
+
+      def repository_noid?
+        repository_id?
+      end
+
       def agree_to_terms_of_service!
         update_column(:agreed_to_terms_of_service, true)
       end

--- a/app/views/shared/_my_actions.html.erb
+++ b/app/views/shared/_my_actions.html.erb
@@ -7,7 +7,9 @@
     <li><%= link_to 'My Works',       catalog_index_path(:'f[generic_type_sim][]' => 'Work', works: 'mine'), class: 'my-works',       role: 'menuitem' %></li>
     <li><%= link_to 'My Collections', collections_path,                                                      class: 'my-collections', role: 'menuitem' %></li>
     <li><%= link_to 'My Profile',     user_profile_path,                                                     class: 'my-account',     role: 'menuitem' %></li>
-    <li><%= link_to 'My Proxies',     person_depositors_path(current_user.person),                           class: 'my-proxies',     role: 'menuitem' %></li>
+    <% if current_user.repository_noid? %>
+    <li><%= link_to 'My Proxies',     person_depositors_path(current_user.repository_noid),                  class: 'my-proxies',     role: 'menuitem' %></li>
+    <% end %>
     <li class="divider"></li>
     <li><%= link_to 'Log Out',        destroy_user_session_path,                                             class: 'log-out',        role: 'menuitem' %></li>
   </ul>

--- a/curate.gemspec
+++ b/curate.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.licenses = ['APACHE2']
 
-  s.add_dependency "rails", "4.0.0"
+  s.add_dependency "rails", "~>4.0.2"
   s.add_dependency "breach-mitigation-rails"
   s.add_dependency 'sufia-models', '~>3.4.0'
 #  s.add_dependency 'hydra', '6.1.0.rc8'

--- a/spec/controllers/curate/collections_controller_spec.rb
+++ b/spec/controllers/curate/collections_controller_spec.rb
@@ -65,7 +65,7 @@ describe Curate::CollectionsController do
           post :create, collection:  { title: 'test title', description: 'test desc'}, add_to_profile: 'true'
         }.to change{ProfileSection.count}.by(1)
       }.to_not change{Collection.count}
-      expect(response).to redirect_to person_path(user.person)
+      expect(response).to redirect_to user_profile_path
     end
   end
 

--- a/spec/models/curate/user_behavior/base_spec.rb
+++ b/spec/models/curate/user_behavior/base_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Curate::UserBehavior::Base do
+  let(:model) do
+    Class.new do
+      include Curate::UserBehavior::Base
+      def initialize(object)
+        @object = object
+      end
+      def method_missing(method_name, *args, &block)
+        @object.send(method_name, *args, &block)
+      end
+      def respond_to_missing?(method_name, *args, &block)
+        @object.respond_to?(method_name, *args, &block)
+      end
+    end
+  end
+  let(:noid) { 'abc-123'}
+  let(:user) { double(repository_id: Sufia::Noid.namespaceize(noid), repository_id?: true)}
+  subject { model.new(user) }
+  its(:repository_noid) { should eq noid }
+  its(:repository_noid?) { should eq true }
+end

--- a/spec/views/shared/_site_actions.html.erb_spec.rb
+++ b/spec/views/shared/_site_actions.html.erb_spec.rb
@@ -20,9 +20,9 @@ describe 'shared/_site_actions.html.erb' do
   end
 
   context 'logged in' do
-    let(:person) { double }
+    let(:repository_noid) { 'abc-123' }
     let(:name) { 'My Display Name' }
-    let(:current_user) { double(name: name, person: person) }
+    let(:current_user) { double(name: name, repository_noid: repository_noid, repository_noid?: true) }
     it 'renders a link to create a new user session' do
       expect(rendered).to_not have_login_section
       expect(rendered).to have_add_content_section do
@@ -39,7 +39,7 @@ describe 'shared/_site_actions.html.erb' do
             with_tag 'a.my-works'
             with_tag 'a.my-collections', with: { href: collections_path}
             with_tag 'a.my-account', with: { href: user_profile_path }
-            with_tag 'a.my-proxies', with: { href: person_depositors_path(person) }
+            with_tag 'a.my-proxies', with: { href: person_depositors_path(repository_noid) }
             with_tag 'a.log-out', with: { href: destroy_user_session_path }
           end
         end


### PR DESCRIPTION
Rails ~>4.0.1 is enforcing parameters when using a member path method
(i.e. person_path(user.person) where user.person was not persisted)

By switching to using the User#repository_noid we also do not need to
load the Person from Fedora on each request (as that is part of the
action bar).

closes #303
closes #303 

Attn: @hortongn and @scherztc ; I pushed this through with a different solution based on a Rails 4.0.1 vulnerability.
