### PR TITLE
Removing validation for contributors

### DIFF
--- a/app/repository_models/article.rb
+++ b/app/repository_models/article.rb
@@ -16,7 +16,6 @@ class Article < ActiveFedora::Base
 
   self.indefinite_article = 'an'
   self.contributor_label = 'Author'
-  validates_presence_of :contributors, message: "Your #{human_readable_type.downcase} must have #{label_with_indefinite_article}."
 
   attribute :title,
     datastream: :descMetadata, multiple: false,

--- a/app/repository_models/dataset.rb
+++ b/app/repository_models/dataset.rb
@@ -24,8 +24,6 @@ class Dataset < ActiveFedora::Base
             multiple: false,
             validates: {presence: { message: 'You must select a license for your dataset.' }}
 
-  validates_presence_of :contributors, message: "Your dataset must have a contributor."
-
   attribute :created,                datastream: :descMetadata, multiple: false
   attribute :description,            datastream: :descMetadata, multiple: false
   attribute :date_uploaded,          datastream: :descMetadata, multiple: false

--- a/app/repository_models/document.rb
+++ b/app/repository_models/document.rb
@@ -6,8 +6,7 @@ class Document < GenericWork
 
   self.indefinite_article = 'an'
   self.contributor_label = 'Author'
-  validates_presence_of :contributors, message: "Your #{human_readable_type.downcase} must have #{label_with_indefinite_article}."
-
+ 
   def self.valid_types
     [ 'Book',
       'Book Chapter',

--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -24,7 +24,6 @@ class Etd < ActiveFedora::Base
 
   self.indefinite_article = 'an'
   self.contributor_label = 'Author'
-  validates_presence_of :contributors, message: "Your #{human_readable_type.downcase} must have #{label_with_indefinite_article}."
 
   with_options datastream: :descMetadata do |ds|
     ds.attribute :contributor,

--- a/app/repository_models/image.rb
+++ b/app/repository_models/image.rb
@@ -26,8 +26,7 @@ class Image < ActiveFedora::Base
     ds.attribute :creator,
       label: "Creator",
       hint: " Primary creator/s of the item.",
-      multiple: true,
-      validates: { presence: { message: "Your #{image_label} must have a creator." } }
+      multiple: true
 
     ds.attribute :date_created,
       default: Date.today.to_s("%Y-%m-%d"),

--- a/lib/generators/curate/work/templates/factory.rb.erb
+++ b/lib/generators/curate/work/templates/factory.rb.erb
@@ -17,7 +17,6 @@ FactoryGirl.define do
 
     before(:create) { |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
-      work.contributors << FactoryGirl.create(:person)
     }
 
     factory :private_<%= singular_table_name %> do

--- a/spec/factories/articles_factory.rb
+++ b/spec/factories/articles_factory.rb
@@ -12,7 +12,6 @@ FactoryGirl.define do
 
     before(:create) { |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
-      work.contributors << FactoryGirl.create(:person)
     }
 
     factory :private_article do

--- a/spec/factories/datasets_factory.rb
+++ b/spec/factories/datasets_factory.rb
@@ -10,7 +10,6 @@ FactoryGirl.define do
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
     before(:create) { |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
-      work.contributors << FactoryGirl.create(:person)
     }
 
     factory :private_dataset do

--- a/spec/factories/etds_factory.rb
+++ b/spec/factories/etds_factory.rb
@@ -16,7 +16,6 @@ FactoryGirl.define do
 
     before(:create) { |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
-      work.contributors << FactoryGirl.create(:person)
     }
 
     factory :private_etd do

--- a/spec/factories/generic_works_factory.rb
+++ b/spec/factories/generic_works_factory.rb
@@ -11,7 +11,6 @@ FactoryGirl.define do
     before(:create) { |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
       work.owner = evaluator.user.user_key
-      work.contributors << FactoryGirl.create(:person)
     }
 
     factory :private_generic_work do

--- a/spec/factories/images_factory.rb
+++ b/spec/factories/images_factory.rb
@@ -11,7 +11,6 @@ FactoryGirl.define do
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
     before(:create) { |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
-      work.contributors << FactoryGirl.create(:person)
     }
 
     factory :private_image do

--- a/spec/support/shared/has_linked_contributors.rb
+++ b/spec/support/shared/has_linked_contributors.rb
@@ -1,11 +1,5 @@
 shared_examples 'it has linked contributors' do
   describe "nested contributors" do
-    describe "without any creator" do
-      it "should have an error" do
-        subject.should_not be_valid
-        subject.errors[:contributors].should == ["Your #{subject.human_readable_type.downcase} must have #{subject.indefinite_article} #{subject.contributor_label.downcase}."]
-      end
-    end
 
     describe "when nested attributes are set" do
       it "should create a new person" do

--- a/spec/support/shared/shared_examples_remotely_identified.rb
+++ b/spec/support/shared/shared_examples_remotely_identified.rb
@@ -2,7 +2,7 @@ shared_examples 'remotely_identified' do |remote_service_name|
   context "by #{remote_service_name}" do
     context 'with valid attributes' do
       subject { FactoryGirl.create(described_class.name.underscore, attributes) }
-      let(:attributes) { { publisher: 'An Interesting Chap!' } }
+      let(:attributes) { { publisher: 'An Interesting Chap!', contributors: [FactoryGirl.create(:person)] } }
 
       it 'mints!', VCR::SpecSupport(cassette_name: "remotely_identified_#{remote_service_name}_mint_#{described_class.name.underscore}") do
         expect {
@@ -15,9 +15,10 @@ shared_examples 'remotely_identified' do |remote_service_name|
         subject { FactoryGirl.build(described_class.name.underscore, attributes: attributes) }
         let(:attributes) { { publisher: [] } }
         it 'fails validation' do
-          subject.should_receive(:remote_doi_assignment_strategy?).and_return(true)
+          subject.stub(:remote_doi_assignment_strategy?).and_return(true)
           expect(subject).to_not be_valid
           expect(subject.errors[:publisher]).to eq(["is required for remote DOI minting"])
+          expect(subject.errors[:contributor]).to eq(["is required for remote DOI minting"])
         end
       end
     end


### PR DESCRIPTION
As much as I would like to say that we should require contributors
Lets instead make it optional. This means we don't have to create
Works with a huge cluster of supporting objects that are likely not
needed in most contexts.
