### PR TITLE
Updating README.md with correct URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It is released under the [Apache 2 License](./LICENSE)
 
 When you generate your new Rails application, you can use Curate's application template:
 ```bash
-$ rails new my_curate_application -m https://raw.github.com/ndlib/curate/master/lib/generators/curate/application_template.rb
+$ rails new my_curate_application -m https://raw.github.com/projecthydra/curate/master/lib/generators/curate/application_template.rb
 ```
 
 ## Or Install By Hand


### PR DESCRIPTION
The application template URL was still referencing ndlib/curate.
The ndlib/curate repository will redirect to projecthydra/curate, but
this is a possible point of confusion.

[ci skip]
