### PR TITLE
Add ability for user to include therubyracer gem

### DIFF
--- a/lib/generators/curate/application_template.rb
+++ b/lib/generators/curate/application_template.rb
@@ -40,6 +40,20 @@ if yes_with_banner?(HELPFUL_DEVELOPMENT_TOOLS)
 
 end
 
+USE_RUBY_RACER =
+  <<-QUESTION_TO_ASK
+Would you like to include the Ruby Racer gem? (Needed in some Linux environments)
+
+More information at http://github.com/cowboyd/therubyracer
+QUESTION_TO_ASK
+
+if yes_with_banner?(USE_RUBY_RACER)
+  with_git("Adding Ruby Racer gem") do
+    gem 'therubyracer', platforms: :ruby
+  end
+
+end
+
 with_git("Results of `bundle install`") do
   run 'bundle install'
 end


### PR DESCRIPTION
Prompt the user to include 'therubyracer' gem when using the
application template.  If user answers 'yes' to prompt, add the
following to the Gemfile and commit the change:

gem 'therubyracer', platforms: :ruby

HYDRASIR-77 #close
