### PR TITLE
Unzip Jetty before exiting application template

### DIFF
--- a/lib/generators/curate/application_template.rb
+++ b/lib/generators/curate/application_template.rb
@@ -91,9 +91,10 @@ if yes_with_banner?(JETTY_QUESTION)
   end
 
   with_git("Downloading jettywrapper") do
-    if yes_with_banner?("Would you like to download jetty now?\n\nThis will take quite awhile based on download speeds.")
+    if yes_with_banner?("Would you like to download and unzip jetty now?\n\nThis will take quite awhile based on download speeds.")
       rake "jetty:download"
       rake "jetty:config"
+      rake "jetty:unzip"
     end
   end
 end


### PR DESCRIPTION
If the user chooses to download Jetty when using the application
template, automatically run 'rake jetty:unzip' before exiting the
script.  Jetty will then be ready to be started by the user.

HYDRASIR-78 #close
