### PR TITLE
Fix for the sorting of Works not sorting correctly

### DIFF
--- a/app/repository_datastreams/article_metadata_datastream.rb
+++ b/app/repository_datastreams/article_metadata_datastream.rb
@@ -44,11 +44,11 @@ class ArticleMetadataDatastream < ActiveFedora::NtriplesRDFDatastream
     end
     map.date_uploaded(to: "dateSubmitted", in: RDF::DC) do |index|
       index.type :date
-      index.as :stored_searchable, :sortable
+      index.as :stored_sortable
     end
     map.date_modified(to: "modified", in: RDF::DC) do |index|
       index.type :date
-      index.as :stored_searchable, :sortable
+      index.as :stored_sortable
     end
     map.recommended_citation({in: RDF::DC, to: 'bibliographicCitation'})
 

--- a/app/repository_datastreams/etd_metadata.rb
+++ b/app/repository_datastreams/etd_metadata.rb
@@ -42,11 +42,11 @@ class EtdMetadata < ActiveFedora::NtriplesRDFDatastream
     end
     map.date_uploaded(to: "dateSubmitted", in: RDF::DC) do |index|
       index.type :date
-      index.as :stored_searchable, :sortable
+      index.as :stored_sortable
     end
     map.date_modified(to: "modified", in: RDF::DC) do |index|
       index.type :date
-      index.as :stored_searchable, :sortable
+      index.as :stored_sortable
     end
     map.language(in: RDF::DC) do |index|
       index.as :stored_searchable, :facetable

--- a/app/repository_datastreams/generic_work_rdf_datastream.rb
+++ b/app/repository_datastreams/generic_work_rdf_datastream.rb
@@ -21,12 +21,12 @@ class GenericWorkRdfDatastream < ActiveFedora::NtriplesRDFDatastream
 
     map.date_uploaded(to: "dateSubmitted", in: RDF::DC) do |index|
       index.type :date
-      index.as :stored_searchable, :sortable
+      index.as :stored_sortable
     end
 
     map.date_modified(to: "modified", in: RDF::DC) do |index|
       index.type :date
-      index.as :stored_searchable, :sortable
+      index.as :stored_sortable
     end
 
     map.issued({in: RDF::DC}) do |index|

--- a/app/repository_datastreams/image_metadata.rb
+++ b/app/repository_datastreams/image_metadata.rb
@@ -39,11 +39,11 @@ class ImageMetadata < ActiveFedora::NtriplesRDFDatastream
     map.format(in: RDF::QualifiedDC, to: 'format#mimetype')
     map.date_uploaded(to: "dateSubmitted", in: RDF::DC) do |index|
       index.type :date
-      index.as :stored_searchable, :sortable
+      index.as :stored_sortable
     end
     map.date_modified(to: "modified", in: RDF::DC) do |index|
       index.type :date
-      index.as :stored_searchable, :sortable
+      index.as :stored_sortable
     end
     map.identifier(in: RDF::DC)
     map.doi(to: "identifier#doi", in: RDF::QualifiedDC)


### PR DESCRIPTION
In order to sort these fields there needs to be a non-multivalued field in Solr for each. For some reason there was just a multivalued field getting indexed.

The old code tries to generate two solr fields (one multivalued, one not), but that code didn't work correctly. I'm not sure if that's a Solrizer bug or a configuration bug in Curate. In any case, there isn't a need to have the multivalued fields for date uploaded and date modified, so we just use the :stored_sortable Solrizer symbol. A reindex needs to run for this change (ActiveFedora::Base.reindex_everything is useful).
