### PR TITLE
Add soft delete option to application template

### DIFF
--- a/lib/generators/curate/application_template.rb
+++ b/lib/generators/curate/application_template.rb
@@ -95,6 +95,13 @@ if yes_with_banner?(JETTY_QUESTION)
       rake "jetty:download"
       rake "jetty:config"
       rake "jetty:unzip"
+
+      if yes_with_banner?("Would you like to turn on soft deleting of works?\n\nThis will preserve deleted objects in the Fedora repository while preventing the works from being displayed in the application.")
+        get 'https://raw.github.com/projecthydra/curate/master/lib/generators/curate/soft_delete/active_fedora_soft_delete_monkey_patch.rb', 'config/initializers/active_fedora_soft_delete_monkey_patch.rb'
+        get 'https://raw.github.com/projecthydra/curate/master/lib/generators/curate/soft_delete/deny-d-objects-and-datastreams.xml', 'jetty/fedora/default/data/fedora-xacml-policies/repository-policies/deny-d-objects-and-datastreams.xml'
+        get 'https://raw.github.com/projecthydra/curate/master/lib/generators/curate/soft_delete/deny-purge.xml', 'jetty/fedora/default/data/fedora-xacml-policies/repository-policies/deny-purge.xml'
+        get 'https://raw.github.com/projecthydra/curate/master/lib/generators/curate/soft_delete/permit-describerepository.xml', 'jetty/fedora/default/data/fedora-xacml-policies/repository-policies/permit-describerepository.xml'
+      end
     end
   end
 end

--- a/lib/generators/curate/soft_delete/active_fedora_soft_delete_monkey_patch.rb
+++ b/lib/generators/curate/soft_delete/active_fedora_soft_delete_monkey_patch.rb
@@ -1,0 +1,92 @@
+
+require 'rubydora/repository'
+require 'active_fedora/digital_object'
+require 'active_fedora/base'
+
+module Rubydora
+  class PerformedSoftDelete < RuntimeError
+    attr_reader :options
+    def initialize(method_name, pid, options)
+      @options = options
+      super("Performed soft delete on '#{pid}' via '#{method_name}'")
+    end
+  end
+
+  class Repository
+
+    # There is likely a better way of doing this, but the ActiveFedora API doesn't
+    # appear to support soft-deletes (i.e. changing the state to 'D')
+    #
+    # So I am intercepting the :purge_object, :purge_datastream, and
+    # :purge_relationship methods and instead of purging, I'm modifying.
+    # the state.
+    module SoftDeleteBehavior
+      extend ActiveSupport::Concern
+      included do
+        before_purge_object do |options|
+          client[object_url(options[:pid],state: ActiveFedora::DELETED_STATE)].put(nil)
+          raise PerformedSoftDelete.new('purge_object', options[:pid], options)
+        end
+        before_purge_datastream do |options|
+          client[datastream_url(options[:pid], options[:dsid], dsState: ActiveFedora::DELETED_STATE )].put(nil)
+          raise PerformedSoftDelete.new('purge_datastream', options[:pid], options)
+        end
+
+        before_purge_relationship do |options|
+          client[object_relationship_url(options[:pid], state: ActiveFedora::DELETED_STATE)].put(nil)
+          raise PerformedSoftDelete.new('purge_relationship', options[:pid], options)
+        end
+      end
+
+      def purge_object(*args)
+        super(*args) rescue PerformedSoftDelete; true
+      end
+      def purge_datastream(*args)
+        super(*args) rescue PerformedSoftDelete; true
+      end
+      def purge_relationship(*args)
+        super(*args) rescue PerformedSoftDelete; true
+      end
+    end
+
+    include SoftDeleteBehavior
+  end
+end
+
+module ActiveFedora
+  DELETED_STATE = 'D'
+  class ActiveObjectNotFoundError < RuntimeError
+    attr_reader :base_exception
+    def initialize(exception, *args)
+      @base_exception = exception
+      super("Unable to find via #{args.inspect} in fedora.")
+    end
+  end
+
+  class Base
+    module SoftDeleteBehavior
+      def exists?(*args)
+        super
+      rescue ActiveObjectNotFoundError, RestClient::Unauthorized
+        true
+      end
+    end
+
+    extend SoftDeleteBehavior
+  end
+
+  class DigitalObject
+    # Application level enforcement of finding a DELETE_STATE object
+    module SoftDeleteBehavior
+      # Because I don't want to be handling RestClient::Unauthorized in a
+      # controller, I want to change the exception to a more meaningful
+      # exception
+      def find(*args)
+        super
+      rescue RestClient::Unauthorized => e
+        raise ActiveObjectNotFoundError.new(e, *args)
+      end
+    end
+    extend SoftDeleteBehavior
+  end
+end

--- a/lib/generators/curate/soft_delete/deny-d-objects-and-datastreams.xml
+++ b/lib/generators/curate/soft_delete/deny-d-objects-and-datastreams.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Policy xmlns="urn:oasis:names:tc:xacml:1.0:policy"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  PolicyId="deny-d-objects-and-datastreams"
+  RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable">
+  <Description>Deny access to any objects or datastreams in the "D" deleted state</Description>
+  <Target>
+    <Subjects>
+        <AnySubject/>
+    </Subjects>
+    <Resources>
+      <Resource>
+        <ResourceMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+          <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">D</AttributeValue>
+          <ResourceAttributeDesignator DataType="http://www.w3.org/2001/XMLSchema#string"
+            AttributeId="urn:fedora:names:fedora:2.1:resource:object:state" MustBePresent="false"/>
+        </ResourceMatch>
+      </Resource>
+      <Resource>
+        <ResourceMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+          <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">D</AttributeValue>
+          <ResourceAttributeDesignator DataType="http://www.w3.org/2001/XMLSchema#string"
+            AttributeId="urn:fedora:names:fedora:2.1:resource:datastream:state" MustBePresent="false"/>
+        </ResourceMatch>
+      </Resource>
+    </Resources>
+    <Actions>
+      <AnyAction/>
+    </Actions>
+  </Target>
+  <Rule RuleId="1" Effect="Deny"/>
+</Policy>

--- a/lib/generators/curate/soft_delete/deny-purge.xml
+++ b/lib/generators/curate/soft_delete/deny-purge.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Policy xmlns="urn:oasis:names:tc:xacml:1.0:policy"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        PolicyId="deny-purge"
+        RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable">
+  <Description>deny any object or datastream purging except for those in the legacy namespaces</Description>
+  <Target>
+    <Subjects>
+      <AnySubject/>
+    </Subjects>
+    <Resources>
+      <AnyResource/>
+    </Resources>
+    <Actions>
+      <Action>
+        <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+          <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-purgeObject</AttributeValue>
+          <ActionAttributeDesignator DataType="http://www.w3.org/2001/XMLSchema#string"
+            AttributeId="urn:fedora:names:fedora:2.1:action:id"/>
+        </ActionMatch>
+      </Action>
+      <Action>
+        <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+          <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-purgeDatastream</AttributeValue>
+          <ActionAttributeDesignator DataType="http://www.w3.org/2001/XMLSchema#string"
+            AttributeId="urn:fedora:names:fedora:2.1:action:id"/>
+        </ActionMatch>
+      </Action>
+    </Actions>
+  </Target>
+  <Rule RuleId="1" Effect="Deny" />
+</Policy>

--- a/lib/generators/curate/soft_delete/permit-describerepository.xml
+++ b/lib/generators/curate/soft_delete/permit-describerepository.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Policy xmlns="urn:oasis:names:tc:xacml:1.0:policy"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        PolicyId="permit-describerepository"
+        RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable">
+  <Description>Permit anyone to access describeRepository</Description>
+  <Target>
+    <Subjects>
+      <AnySubject/>
+    </Subjects>
+    <Resources>
+      <AnyResource/>
+    </Resources>
+    <Actions>
+      <Action>
+        <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+          <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-describeRepository</AttributeValue>
+          <ActionAttributeDesignator DataType="http://www.w3.org/2001/XMLSchema#string"
+            AttributeId="urn:fedora:names:fedora:2.1:action:id"/>
+        </ActionMatch>
+      </Action>
+    </Actions>
+  </Target>
+  <Rule RuleId="1" Effect="Permit"/>
+</Policy>


### PR DESCRIPTION
Edited the application template to prompt the user to enable soft
delete functionality.  The user will only be asked to enable delete
if they chose to install and unzip jetty.  This is because jetty
(Fedora) needs to be in place so we have a place to copy the xacml
files.

The monkey patch and xacml files are stored in the
./lib/generatator/curate/soft_delete directory so the application
template can download the files from the online repository.

HYDRASIR-122 #close
