### PR TITLE
Create a Repository Manager role

### DIFF
--- a/app/models/concerns/curate/ability.rb
+++ b/app/models/concerns/curate/ability.rb
@@ -7,6 +7,14 @@ module Curate
 
     def curate_permissions
       alias_action :confirm, :copy, :to => :update
+      if current_user.manager?
+        can [:edit, :update, :destroy], :all
+        cannot [:edit, :update, :destroy], Person
+        cannot [:edit, :update, :destroy], Profile do |p|
+          p.pid != current_user.profile.pid
+        end
+      end
+
       can :edit, Person do |p|
         p.pid == current_user.repository_id
       end

--- a/app/models/curate/user_behavior/base.rb
+++ b/app/models/curate/user_behavior/base.rb
@@ -27,6 +27,15 @@ module Curate
         # override
       end
 
+      def manager?
+        username = self.respond_to?(:username) ? self.username : self.to_s
+        !!manager_usernames.include?(username)
+      end
+
+      def manager_usernames
+        @manager_usernames ||= YAML.load(ERB.new(Rails.root.join('config/manager_usernames.yml').read).result)[Rails.env]['manager_usernames']
+      end
+
       def name
         read_attribute(:name) || user_key
       end

--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -95,6 +95,9 @@ This generator makes the following changes to your application:
     end
   end
 
+  def create_manager_usernames
+    create_file('config/manager_usernames.yml', "development:\n  manager_usernames:\n  - manager@example.com\ntest:\n  manager_usernames:\n  - manager@example.com\nproduction:\n  manager_usernames:\n  - manager@example.com\n")
+  end
 
   def create_recipients_list
     create_file('config/recipients_list.yml', "---\n- hello@world.com\n")

--- a/spec/abilities/generic_file_abilities_spec.rb
+++ b/spec/abilities/generic_file_abilities_spec.rb
@@ -29,6 +29,18 @@ describe "User" do
         }
       end
 
+      describe 'as a repository manager' do
+        let(:email) { 'manager@example.com' }
+        let(:manager_user) { FactoryGirl.create(:user, email: email) }
+        let(:creating_user) { user }
+        let(:current_user) { manager_user }
+        it {
+          should be_able_to(:create, GenericFile.new)
+          should be_able_to(:update, generic_file)
+          should be_able_to(:destroy, generic_file)
+        }
+      end
+
       describe 'another authenticated user' do
         let(:creating_user) { FactoryGirl.create(:user) }
         let(:current_user) { user }

--- a/spec/abilities/generic_work_abilities_spec.rb
+++ b/spec/abilities/generic_work_abilities_spec.rb
@@ -35,6 +35,18 @@ describe "User" do
         }
       end
 
+      describe 'as a repository manager' do
+        let(:email) { 'manager@example.com' }
+        let(:manager_user) { FactoryGirl.create(:user, email: email) }
+        let(:creating_user) { user }
+        let(:current_user) { manager_user }
+        it {
+          should be_able_to(:create, GenericWork.new)
+          should be_able_to(:update, generic_work)
+          should be_able_to(:destroy, generic_work)
+        }
+      end
+
       describe 'another authenticated user' do
         let(:creating_user) { FactoryGirl.create(:user) }
         let(:current_user) { user }


### PR DESCRIPTION
Create a 'manager' method in base.rb that reads a list of manager
email addresses from config/manager_usernames.yml. Modify ability.rb
to check that the current user is a manager and grant
edit/update/destroy access on everything except users/profiles.
Modify curate_generator.rb to create a default yaml file.
(Editing other users and making everything discoverable will be done
in future stories)

HYDRASIR-201 #close
HYDRASIR-202 #close
