### PR TITLE
Pinning Rubydora version to 1.6.5

### DIFF
--- a/curate.gemspec
+++ b/curate.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'chronic', '>= 0.10.2'
   s.add_dependency 'virtus'
   s.add_dependency 'rails_autolink'
+  s.add_dependency 'rubydora', '1.6.5'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "factory_girl_rails"


### PR DESCRIPTION
Pinned the Rubydora version to 1.6.5 until we can configure
soft_delete to work with Rubydora versions greater than 1.7.0

HYDRASIR-236 #close
