### PR TITLE
Make partial matching work for keyword and autocomplete searches

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -36,13 +36,25 @@ class CatalogController < ApplicationController
     solr_name('desc_metadata__date_modified', :stored_sortable , type: :date)
   end
 
+  def self.search_config
+     # Set parameters to send to SOLR
+     # First inspect contents of the hash from Yaml configuration file
+     # See config/search_config.yml
+     initialized_config = Curate.configuration.search_config['catalog']
+     # If the hash is empty, set reasonable defaults for this search type
+     if initialized_config.nil?
+        Hash['qf' => ['desc_metadata__title_tesim','desc_metadata__name_tesim'],'qt' => 'search','rows' => 10]
+     else
+        initialized_config
+     end
+  end
 
   configure_blacklight do |config|
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
-      qf: [solr_name("desc_metadata__title", :stored_searchable), solr_name("desc_metadata__name", :stored_searchable)],
-      qt: "search",
-      rows: 10
+      qf: search_config['qf'],
+      qt: search_config['qt'],
+      rows: search_config['rows']
     }
 
     # solr field configuration for search results/index views

--- a/app/controllers/curate/people_controller.rb
+++ b/app/controllers/curate/people_controller.rb
@@ -11,13 +11,26 @@ class Curate::PeopleController < ApplicationController
   before_filter :breadcrumb, only: [:show]
   self.solr_search_params_logic += [:only_users]
 
+  def self.search_config
+     # Set parameters to send to SOLR
+     # First inspect contents of the hash from Yaml configuration file
+     # See config/search_config.yml
+     initialized_config = Curate.configuration.search_config['people']
+     # If the hash is empty, set reasonable defaults for this search type
+     if initialized_config.nil?
+        Hash['qf' => 'desc_metadata__name_tesim','fl' => 'desc_metadata__name_tesim id','qt' => 'search','rows' => 10]
+     else
+        initialized_config
+     end
+  end
+
   configure_blacklight do |config|
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
-      qf: solr_name("desc_metadata__name", :stored_searchable),
-      fl: solr_name("desc_metadata__name", :stored_searchable) + ' id',
-      qt: "search",
-      rows: 10
+      qf: search_config['qf'],
+      fl: search_config['fl'],
+      qt: search_config['qt'],
+      rows: search_config['rows']
     }
 
     # solr field configuration for search results/index views

--- a/lib/curate/configuration.rb
+++ b/lib/curate/configuration.rb
@@ -20,6 +20,12 @@ module Curate
       }
     end
 
+    # Configure default search options from config/search_config.yml
+    attr_writer :search_config
+    def search_config
+      @search_config ||= "search_config not set"
+    end
+
     # Configure the application root url.
     attr_writer :application_root_url
     def application_root_url

--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -58,6 +58,16 @@ This generator makes the following changes to your application:
     gsub_file 'config/routes.rb', /^\s+root.+$/, "  root 'catalog#index'"
   end
 
+
+  def create_search_config
+    create_file('config/search_config.yml', "development:\ntest:\nproduction:\n", force: true)
+    search_options = "  catalog:\n  people:\n"
+    inject_into_file 'config/search_config.yml', search_options, after: /development\:\n/, force: true
+    inject_into_file 'config/search_config.yml', search_options, after: /test\:\n/, force: true
+    inject_into_file 'config/search_config.yml', search_options, after: /production\:\n/, force: true
+  end
+
+
   DEFAULT_CURATION_CONCERNS = [:generic_works, :datasets, :articles, :etds, :images, :documents]
 
   def create_curate_config
@@ -73,6 +83,10 @@ This generator makes the following changes to your application:
       data << ""
       data << "  # # Used for constructing permanent URLs"
       data << "  # config.application_root_url = 'https://repository.higher.edu/'"
+      data << ""
+      data << "  # # Used to load values for constructing SOLR searches"
+      data << "  search_config_file = File.join(Rails.root, 'config', 'search_config.yml')"
+      data << "  config.search_config = YAML::load(File.open(search_config_file))[Rails.env].with_indifferent_access"
       data << ""
       data << "  # # Override the file characterization runner that is used"
       data << "  # config.characterization_runner = lambda {|filename| … }"

--- a/lib/generators/curate/search_config/search_config_generator.rb
+++ b/lib/generators/curate/search_config/search_config_generator.rb
@@ -1,0 +1,177 @@
+# -*- encoding : utf-8 -*-
+
+require 'rails/generators'
+
+def yes_with_banner?(message, banner = "*" * 80)
+  yes?("\n#{banner}\n\n#{message}\n#{banner}\nType y(es) to confirm:")
+end
+
+class Curate::SearchConfigGenerator < Rails::Generators::Base
+
+  source_root Rails.root
+
+  desc """
+This generator makes the following changes:
+ 1. Optionally enables partial searches in SOLR schema using EdgeNGram filtered fields
+ 2. Optionally copies resulting SOLR configuration files to packaged Jetty (if exists)
+ 3. Configures config/search_config.yml with resulting search options to be used by controllers
+"""
+
+NGRAM_QUESTION =
+<<-QUESTION_TO_ASK
+Would you like to enable partial term matches for searches in your SOLR configuration?
+ 
+This will create fields that use EdgeNGram filters, which might impact index sizes.
+
+This will instruct SOLR to copy a configurable list of fields into a single
+field for keyword searching instead of searching fields individually.
+
+QUESTION_TO_ASK
+
+PARTIAL_SEARCH_QUESTION =
+<<-QUESTION_TO_ASK
+Would you like to enable partial term matches for searches in your SOLR configuration?
+ 
+This will create fields that use EdgeNGram filters, which might impact index sizes.
+
+This will instruct SOLR to copy a configurable list of fields into a single
+field for keyword searching instead of searching fields individually.
+
+QUESTION_TO_ASK
+
+JETTY_SOLR_QUESTION =
+<<-QUESTION_TO_ASK
+Would you like to enable these SOLR configuration options in the local Jetty
+instance installed with Curate?
+
+This will copy the resulting configuration files from solr_conf/conf to the SOLR
+instance inside of the included Jetty server.
+QUESTION_TO_ASK
+
+EDGE_FILTER_CONFIG =
+<<-CONFIG_BLOCK
+    <!-- The following definition was created during Curate installation -->
+    <!-- A text field with EdgeNGram filtering for partial matches -->
+    <fieldType name="text_en_ef" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+        <tokenizer class="solr.ICUTokenizerFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <!-- EnglishMinimalStemFilterFactory is less aggressive than PorterStemFilterFactory: -->
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+        <filter class="solr.TrimFilterFactory"/>
+        <filter class="solr.EdgeNGramFilterFactory" minGramSize="3" maxGramSize="15" side="front"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.ICUTokenizerFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <!-- EnglishMinimalStemFilterFactory is less aggressive than PorterStemFilterFactory: -->
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+        <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+CONFIG_BLOCK
+
+AGGREGATE_CONFIG =
+<<-CONFIG_BLOCK
+    <!-- The following definition was created during Curate installation -->
+    <!-- The all_text_tesim field is an aggregate of all *_tesim fields for overall keyword searching -->
+    <!-- desc_metadata_name_ef is an alternate source for people names that has been edge filtered -->
+    <field name="all_text_tesim" type="text_en_ef" stored="true" indexed="true" multiValued="true"/>
+    <field name="desc_metadata_name_ef" type="text_en_ef" stored="true" indexed="true" multiValued="true"/>
+
+CONFIG_BLOCK
+
+COPYFIELD_CONFIG =
+<<-CONFIG_BLOCK
+
+    <!-- The following definition was created during Curate installation -->
+    <!-- Maintain aggregate of *_tesim fields in all_text_tesim field -->
+    <copyField source="*_tesim" dest="all_text_tesim"/>
+    <!-- Maintain an alternate source for people names that has been edge filtered -->
+    <copyField source="desc_metadata__name_tesim" dest="desc_metadata_name_ef"/>
+
+CONFIG_BLOCK
+
+FINAL_STATUS = 
+<<-BLOCK
+Optional SOLR configuration complete. 
+
+Please review files in ./solr_conf/conf. Changes are commented with the phrase
+'created during Curate installation'. If you are using an external instance of
+SOLR or chose not to copy resulting files to Jetty, then you must review/copy
+the configuration files appropriately for your situation.
+
+Also consult the changes to 'config/search_config'. This file is used to determine
+SOLR options set in search controllers.
+BLOCK
+
+  def prepare_yaml_file
+    banner = "\n" + "*" * 80 + "\n"
+    puts banner
+    say_status("Preparing","Preparing search configuration files...", :green)
+    puts banner
+    yamlfile = Rails.root.join("config","search_config.yml")
+    qt_option = "    qt: search\n"
+    inject_into_file yamlfile, qt_option, after: /.*.\scatalog:\n/, force: true
+    inject_into_file yamlfile, qt_option, after: /.*.\speople:\n/, force: true
+  end
+
+  def config_edge_filters
+    myfile = Rails.root.join("solr_conf","conf","schema.xml")
+    config_target = /.*A text field with defaults appropriate for English --\>\n/
+    say_status(".....", "Configuring SOLR with an EdgeNGramFilterFactory field type", :green)
+    say_status(".....", "Making changes to "+myfile.to_s, :green)
+    inject_into_file myfile, EDGE_FILTER_CONFIG, before: config_target
+  end
+
+  def config_partial_search
+    myschema = Rails.root.join("solr_conf","conf","schema.xml")
+    myconfig = Rails.root.join("solr_conf","conf","solrconfig.xml")
+    yamlfile = Rails.root.join("config","search_config.yml")
+    schema_target = /.*\<\/fields\>.*\n/
+    schema_target = /.*\<\/fields\>.*\n/
+    catalog_qf_opts = 'desc_metadata__title_tesim,desc_metadata__name_tesim'
+    people_qf_opts = 'desc_metadata__name_tesim'
+    if yes_with_banner?(PARTIAL_SEARCH_QUESTION)
+      say_status(".....", "Configuring SOLR to return partial matches for searches", :green)
+      say_status(".....", "Configuring SOLR to aggregate fields for keyword searches", :green)
+      say_status(".....", "About to make changes to "+myschema.to_s+" and "+myconfig.to_s, :green)
+      inject_into_file myschema, AGGREGATE_CONFIG, before: schema_target
+      inject_into_file myschema, COPYFIELD_CONFIG, after: schema_target
+      inject_into_file myconfig, "          all_text_tesim\n", after: /.*\<str name="qf"\>\n.*id\n/
+      inject_into_file myconfig, "          all_text_tesim^10\n", after: /.*\<str name="pf"\>\n/
+      catalog_qf_opts = 'all_text_tesim'
+      people_qf_opts = 'desc_metadata_name_ef'
+    else
+      say_status(".....", "SOLR will not return partial matches for searches", :green)
+    end
+    inject_into_file yamlfile, "    qf: [#{catalog_qf_opts}]\n", after: /.\scatalog:\n/
+    inject_into_file yamlfile, "    fl: desc_metadata__name_tesim id\n", after: /.\speople:\n/
+    inject_into_file yamlfile, "    qf: [#{people_qf_opts}]\n", after: /.\speople:\n/
+  end
+
+  def copy_solr_configs
+    my_solr_path = "solr_conf/conf"  
+    my_jetty_dev_path = Rails.root.join("jetty","solr","development-core","conf")
+    my_jetty_test_path = Rails.root.join("jetty","solr","test-core","conf")
+    if File.directory?(Rails.root+"jetty")
+      if yes_with_banner?(JETTY_SOLR_QUESTION)
+        say_status(".....", "Copying SOLR config files to Jetty", :green)
+        copy_file my_solr_path+"/schema.xml", my_jetty_dev_path+"schema.xml", force: true
+        copy_file my_solr_path+"/schema.xml", my_jetty_test_path+"schema.xml", force: true
+        copy_file my_solr_path+"/solrconfig.xml", my_jetty_dev_path+"solrconfig.xml", force: true
+        copy_file my_solr_path+"/solrconfig.xml", my_jetty_test_path+"solrconfig.xml", force: true
+      end
+    end
+  end
+
+  def final_status
+    banner = "\n" + "*" * 80 + "\n"
+    puts banner
+    say_status("Finished",FINAL_STATUS, :green)
+    puts banner
+  end
+end


### PR DESCRIPTION
To enable partial matching for various search types, the use of
EdgeNGram filters were employed in the SOLR schema. This was
accomplished in a way that also adds configurability into the
search system. This was not only desirable but necessary in order
to constrain the use of edge filtered fields to specific use cases
so as to not introduce unpredictable behavior. Configurability
means that:
- a new generator named curate:search_config changes SOLR
   schema and config files based on user questions
- a configurable Yaml file (config/search_conig.yml) is used at
   start that makes a hash available to controllers involved in SOLR
   searches. This Yaml file is changed by the curate:search_config
   generator to reflect SOLR config options.

Changes in this commit:
- Create curate:search_config generator in search_config_generator.rb
   that edits SOLR schema and config files based on user questions.
- Modify curate_generator.rb to create initial search_config.yml file.
- Modify curate_generator.rb to write new lines to curate_initializer.rb
   that will initialize search_config hash from Yaml file.
- Modify catalog_controller.rb and people_controller.rb to change hard
   coded search options to read from initialized search_config hash.
- Modify configuration.rb to create accessors so that hash from
  Yaml file is available as Curate.configuration.search_config
  
  HYDRASIR-14 #close
  HYDRASIR-15 #close
