### PR TITLE
Disable requiring TurboLinks in the curate app generator.

### DIFF
--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -20,6 +20,7 @@ This generator makes the following changes to your application:
  4. Adds the curate abilities
  5. Adds a user migration
  6. Adds views for devise
+ 7. Disables TurboLinks
        """
 
   def run_required_generators
@@ -141,6 +142,7 @@ This generator makes the following changes to your application:
     insert_into_file "app/assets/javascripts/application.js", :before => '//= require_tree .' do
       "//= require curate\n"
     end
+    gsub_file "app/assets/javascripts/application.js", /= +require +turbolinks/, " -- For Hydramata, removed '= require turbolinks' here.--"
   end
 
   def remove_blacklight


### PR DESCRIPTION
By disabling TurboLinks, several user interface issues involving javascript are resolved.  This fix addresses any future applications generated from Curate.  Applications already generated from Curate will need to remove this line from their application's /app/assets/javascripts/application.js file:
             //= require turbolinks

HYDRASIR-145 #close
HYDRASIR-179 #close
HYDRASIR-180 #close
HYDRASIR-144 #close
HYDRASIR-225 #close

[ci skip]
