### PR TITLE
TurboLinks issues fixed in a way that does not exclude TurboLinks

### DIFF
--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -11,6 +11,7 @@
     <%= csrf_meta_tag %>
 
     <%= stylesheet_link_tag 'application' %>
+    <%= javascript_include_tag 'application' %>
     <%= javascript_include_tag 'modernizr' %>
     <%= render :partial => '/ga', :formats => [:html] -%>
   </head>
@@ -18,7 +19,6 @@
 
     <%= content_for?(:body) ? yield(:body) : yield %>
 
-    <%= javascript_include_tag 'application' %>
 
     <% unless Rails.env.production? %>
     <!-- Rendered through: <%= yield(:layout_name) %>boilerplate -->

--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -20,7 +20,6 @@ This generator makes the following changes to your application:
  4. Adds the curate abilities
  5. Adds a user migration
  6. Adds views for devise
- 7. Disables TurboLinks
        """
 
   def run_required_generators
@@ -142,7 +141,6 @@ This generator makes the following changes to your application:
     insert_into_file "app/assets/javascripts/application.js", :before => '//= require_tree .' do
       "//= require curate\n"
     end
-    gsub_file "app/assets/javascripts/application.js", /= +require +turbolinks/, " -- For Hydramata, removed '= require turbolinks' here.--"
   end
 
   def remove_blacklight


### PR DESCRIPTION
1. Re-enable requiring TurboLinks in the curate app generator.
2. Move javascript include tag for application.js from the body to the head of the boilerplate.html.erb.
