### PR TITLE
Repository manager can discover everything

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -19,7 +19,7 @@ class CatalogController < ApplicationController
   CatalogController.solr_search_params_logic += [:exclude_unwanted_models]
 
   before_filter :agreed_to_terms_of_service!
-  
+
   skip_before_filter :default_html_head
 
   def index
@@ -71,7 +71,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type of Work", limit: 5
     config.add_facet_field solr_name(:desc_metadata__creator, :facetable), label: "Creator", helper_method: :creator_name_from_pid, limit: 5
     config.add_facet_field solr_name(:collection, :facetable), label: "Collection",  helper_method: :collection_title_from_pid, limit: 5
-    
+
     config.add_facet_field solr_name("desc_metadata__tag", :facetable), label: "Keyword", limit: 5
     config.add_facet_field solr_name("desc_metadata__subject", :facetable), label: "Subject", limit: 5
     config.add_facet_field solr_name("desc_metadata__language", :facetable), label: "Language", limit: 5
@@ -340,6 +340,14 @@ class CatalogController < ApplicationController
   end
 
   protected
+
+    # Override Hydra::PolicyAwareAccessControlsEnforcement
+    def gated_discovery_filters
+      if current_user and current_user.manager?
+        return []
+      end
+      super
+    end
 
     # Overriding blacklight so that the search results can be displayed in a way compatible with
     # tokenInput javascript library.  This is used for suggesting "Related Works" to attach.

--- a/app/models/concerns/curate/ability.rb
+++ b/app/models/concerns/curate/ability.rb
@@ -8,7 +8,7 @@ module Curate
     def curate_permissions
       alias_action :confirm, :copy, :to => :update
       if current_user.manager?
-        can [:edit, :update, :destroy], :all
+        can [:discover, :show, :read, :edit, :update, :destroy], :all
         cannot [:edit, :update, :destroy], Person
         cannot [:edit, :update, :destroy], Profile do |p|
           p.pid != current_user.profile.pid

--- a/spec/abilities/generic_file_abilities_spec.rb
+++ b/spec/abilities/generic_file_abilities_spec.rb
@@ -36,6 +36,7 @@ describe "User" do
         let(:current_user) { manager_user }
         it {
           should be_able_to(:create, GenericFile.new)
+          should be_able_to(:read, generic_file)
           should be_able_to(:update, generic_file)
           should be_able_to(:destroy, generic_file)
         }

--- a/spec/abilities/generic_work_abilities_spec.rb
+++ b/spec/abilities/generic_work_abilities_spec.rb
@@ -42,6 +42,7 @@ describe "User" do
         let(:current_user) { manager_user }
         it {
           should be_able_to(:create, GenericWork.new)
+          should be_able_to(:read, generic_work)
           should be_able_to(:update, generic_work)
           should be_able_to(:destroy, generic_work)
         }

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -46,4 +46,25 @@ describe CatalogController do
     end
 
   end
+
+  describe "when logged in as a repository manager" do
+    let(:creating_user) { FactoryGirl.create(:user) }
+    let(:email) { 'manager@example.com' }
+    let(:manager_user) { FactoryGirl.create(:user, email: email) }
+    let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+    let!(:work1) {
+      FactoryGirl.create_curation_concern(:generic_work, creating_user, { visibility: visibility })
+    }
+    before do
+      sign_in manager_user
+    end
+    context "searching all works" do
+      it "should return other users' private works" do
+        get 'index', 'f' => {'generic_type_sim' => 'Work'}
+        response.should be_successful
+        assigns(:document_list).map(&:id).should == [work1.id]
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
Add discover, show, and read abilities to repository managers.
Override the gated_discovery_filters method in Hydra access controls
so that repository managers have no filters and can discover
everything.

HYDRASIR-262 #close
