### PR TITLE
Update UI for editing group membership

### DIFF
--- a/app/views/hydramata/groups/_form.html.erb
+++ b/app/views/hydramata/groups/_form.html.erb
@@ -20,7 +20,7 @@
   <div class="control-group string required group_title">
     <span class="control-label">
       <label class="string required" for="group_title">
-        <abbr title="" data-original-title="required">*</abbr> Title
+        <abbr title="" data-original-title="required">*</abbr>Group Name
       </label>
     </span>
     <div class="controls">

--- a/app/views/hydramata/groups/_linked_members.html.erb
+++ b/app/views/hydramata/groups/_linked_members.html.erb
@@ -1,49 +1,83 @@
 <% label ||= 'Members' %>
 <div class="control-group required link-users" id="members">
-  <span class="control-label">
-    <label class="required" for="<%=f.object_name.downcase%>_members_attributes_0_name">
-      <%= label %>
-    </label>
-  </span>
+  <div class="row">
+    <div class="span4">
+      <span class="control-label">
+        <label class="required" for="<%=f.object_name.downcase%>_members_attributes_0_name">
+          <%= label %>
+        </label>
+      </span>
+    </div>
+    <div class="span2 text-center">
+      Can edit group
+    </div>
+  </div>
   <div class="controls">
     <% prefix = f.object_name.downcase %>
 
     <script id="entry-template" type="text/x-handlebars-template">
       <li class="field-wrapper input-append">
-        <label class="checkbox inline-checkbox"><%= check_box_tag "group_member[edit_users_ids][]", false %>manager?</label>
-        <input id="<%=prefix %>_members_attributes_{{index}}_id" name="<%=prefix %>[members_attributes][{{index}}][id]" type="hidden" value="" />
-        <input class="input-xlarge autocomplete-users" data-url="/people" id="<%=prefix %>_members_attributes_{{index}}_name" name="<%=prefix %>[members_attributes][{{index}}][name]" type="text" value="" />
-        <span class="field-controls"><button class="btn btn-success add"><i class="icon-white icon-plus"></i><span>Add</span></button></span>
+        <div class="row">
+          <div class="span4">
+            <input class="input-xlarge autocomplete-users" data-url="/people" id="<%=prefix %>_members_attributes_{{index}}_name" name="<%=prefix %>[members_attributes][{{index}}][name]" type="text" value="" />
+            <span class="field-controls">
+              <button class="btn btn-success add">
+                <i class="icon-white icon-plus"></i>
+                <span>Add</span>
+              </button>
+            </span>
+          </div>
+          <div class="span2 text-center">
+            <label class="checkbox inline-checkbox"><%= check_box_tag "group_member[edit_users_ids][]", false %></label>
+            <input id="<%=prefix %>_members_attributes_{{index}}_id" name="<%=prefix %>[members_attributes][{{index}}][id]" type="hidden" value="" />
+          </div>
+        </div>
       </li>
     </script>
     <script id="existing-user-template" type="text/x-handlebars-template">
       <li class="field-wrapper input-append">
-        <label class="checkbox inline-checkbox"><%= check_box_tag "group_member[edit_users_ids][]", "{{value}}", @group.edit_users.include?("{{value}}") %>manager?</label>
-        <span class="linked-user"><a href="/people/{{value}}" target="_new">{{label}}</a></span>
-        <input type="hidden" name="<%=prefix %>[members_attributes][{{index}}][id]" value="{{value}}">
-        <span class="field-controls"><button class="btn btn-danger remove"><i class="icon-white icon-minus"></i><span>Remove</span></button></span>
+        <div class="row">
+          <div class="span4">
+            <span class="linked-user">
+              <a href="/people/{{value}}" target="_new">{{label}}</a>
+            </span>
+            <input type="hidden" name="<%=prefix %>[members_attributes][{{index}}][id]" value="{{value}}">
+            <span class="field-controls">
+              <button class="btn btn-danger remove">
+                <i class="icon-white icon-minus"></i>
+                <span>Remove</span>
+              </button>
+            </span>
+          </div>
+          <div class="span2 text-center">
+            <label class="checkbox inline-checkbox"><%= check_box_tag "group_member[edit_users_ids][]", "{{value}}", @group.edit_users.include?("{{value}}") %></label>
+          </div>
+        </div>
       </li>
     </script>
 
     <ul class="listing">
       <% if !@group.nil? && @group.members != [] %>
-       <%= f.fields_for :members do |memberField| %>
+        <%= f.fields_for :members do |memberField| %>
         <li class="field-wrapper input-append">
-        <%= memberField.hidden_field :id %>
-        <%= memberField.hidden_field :_destroy %>
-        <label class="checkbox inline-checkbox"><%= check_box_tag "group_member[edit_users_ids][]", memberField.object.id, @group.edit_users.include?(memberField.object.depositor) %>manager?</label>
-        <% if memberField.object.persisted? %>
-          <span class="linked-user"><%=link_to memberField.object.name, memberField.object, target: '_new' %></span>
-        <% else %>
-          <%= memberField.text_field :name, class: 'input-xlarge autocomplete-users', 'data-url' => people_path, required: memberField.index == 0  %>
+          <div class="row">
+            <%= memberField.hidden_field :id %>
+            <%= memberField.hidden_field :_destroy %>
+            <div class="span4">
+              <% if memberField.object.persisted? %>
+                <span class="linked-user"><%=link_to memberField.object.name, memberField.object, target: '_new' %></span>
+              <% else %>
+                <%= memberField.text_field :name, class: 'input-xlarge autocomplete-users', 'data-url' => people_path, required: memberField.index == 0  %>
+              <% end %>
+              <span class="field-controls"></span>
+            </div>
+            <div class="span2 text-center">
+              <label class="checkbox inline-checkbox"><%= check_box_tag "group_member[edit_users_ids][]", memberField.object.id, @group.edit_users.include?(memberField.object.depositor) %></label>
+            </div>
+          </div>
+        </li>
         <% end %>
-
-        <span class="field-controls"></span>
-      </li>
-    <% end %>
       <% end %>
-
     </ul>
-
   </div>
 </div>


### PR DESCRIPTION
Change "Title" to "Group Name". Change the "manager?" checkbox for each item to
a column with the heading "Can edit group". Use bootstrap '.row' and '.spanX'
classes to position elements correctly. Reformat HTML.
