### PR TITLE
Repository managers can edit users and profiles

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,6 +2,39 @@ class RegistrationsController < Devise::RegistrationsController
   include Curate::ThemedLayoutController
   with_themed_layout '1_column'
 
+  def update
+    if current_user.manager?
+      self.resource = resource_class.to_adapter.get!(User.find(params[:user][:id]))
+    else
+      self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
+    end
+    prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
+
+    if current_user.manager?
+      if account_update_params[:password].blank?
+        account_update_params.delete("password")
+        account_update_params.delete("password_confirmation")
+      end
+      successfully_updated = resource.update_without_password(account_update_params)
+    else
+      successfully_updated = update_resource(resource, account_update_params)
+    end
+
+    if successfully_updated
+      yield resource if block_given?
+      if is_flashing_format?
+        flash_key = update_needs_confirmation?(resource, prev_unconfirmed_email) ?
+          :update_needs_confirmation : :updated
+        set_flash_message :notice, flash_key
+      end
+      sign_in resource_name, resource, bypass: true unless current_user.manager?
+      respond_with resource, location: after_update_path_for(resource)
+    else
+      clean_up_passwords resource
+      respond_with resource
+    end
+  end
+
   protected
 
   def after_update_path_for(resource)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,23 @@
+class UsersController < ApplicationController
+  include Curate::ThemedLayoutController
+  with_themed_layout '1_column'
+
+  def edit
+    render 'registrations/edit'
+  end
+
+  def resource_name
+    :user
+  end
+
+  def resource
+    @resource ||= User.find(params[:id])
+  end
+
+  def devise_mapping
+    @devise_mapping ||= Devise.mappings[:user]
+  end
+
+  helper_method :resource_name, :resource, :devise_mapping
+
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -88,6 +88,19 @@ class Account
     end
   end
 
+  def update_without_password(initial_params, *options)
+    params = normalize_update_params(initial_params)
+    extract_user_and_person_attributes_for_update(params)
+    if update_user_without_password(*options) &&
+        update_person &&
+        update_profile
+      true
+    else
+      collect_errors
+      false
+    end
+  end
+
   delegate :persisted?, :to_param, :to_key, :new_record?, to: :user
 
   def method_missing(method_name, *args, &block)
@@ -131,6 +144,10 @@ class Account
 
   def update_user(*options)
     user.update_with_password(user_attributes, *options)
+  end
+
+  def update_user_without_password(*options)
+    user.update_attributes(user_attributes, *options)
   end
 
   def create_person

--- a/app/models/concerns/curate/ability.rb
+++ b/app/models/concerns/curate/ability.rb
@@ -9,10 +9,6 @@ module Curate
       alias_action :confirm, :copy, :to => :update
       if current_user.manager?
         can [:discover, :show, :read, :edit, :update, :destroy], :all
-        cannot [:edit, :update, :destroy], Person
-        cannot [:edit, :update, :destroy], Profile do |p|
-          p.pid != current_user.profile.pid
-        end
       end
 
       can :edit, Person do |p|

--- a/app/models/curate/user_behavior/base.rb
+++ b/app/models/curate/user_behavior/base.rb
@@ -29,7 +29,8 @@ module Curate
       end
 
       def manager_usernames
-        @manager_usernames ||= YAML.load(ERB.new(Rails.root.join('config/manager_usernames.yml').read).result)[Rails.env]['manager_usernames']
+        manager_config = 'config/manager_usernames.yml'
+        File.exist?(manager_config) ? @manager_usernames ||= YAML.load(ERB.new(Rails.root.join(manager_config).read).result)[Rails.env]['manager_usernames'] : @manager_usernames = ''
       end
 
       def name

--- a/app/views/curate/people/show.html.erb
+++ b/app/views/curate/people/show.html.erb
@@ -29,7 +29,11 @@
 
     <% if can? :edit, @person %>
       <div class="form-action">
-        <%= link_to "Update Personal Information", edit_user_registration_path, class: 'btn btn-primary' %>
+        <% if current_user.manager? %>
+          <%= link_to "Update #{@person.name}'s Information", edit_user_path(User.where(repository_id: @person.id).first.id), class: 'btn btn-primary' %>
+        <% else %>
+          <%= link_to "Update Personal Information", edit_user_registration_path, class: 'btn btn-primary' %>
+        <% end %>
       </div>
     <% end %>
   </div>
@@ -52,10 +56,10 @@
       </p>
     <% end %>
 
-    <% if can_edit_profile_collection?(@person) %>
-      <div class="form-action">
-        <%= link_to 'Add a Section to my Profile', new_collection_path(add_to_profile: true), class: 'btn btn-primary' %>
-      </div>
+    <% if can_edit_profile_collection?(@person) && @person == current_user.person %>
+        <div class="form-action">
+          <%= link_to 'Add a Section to my Profile', new_collection_path(add_to_profile: true), class: 'btn btn-primary' %>
+        </div>
     <% end %>
   </div>
 </div>

--- a/app/views/registrations/_form_account_deactivation.html.erb
+++ b/app/views/registrations/_form_account_deactivation.html.erb
@@ -2,6 +2,6 @@
 
 <div class="row">
   <div class="span12 form-actions">
-    <%= button_to "Cancel My Account", cancel_registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: 'btn btn-danger' %>
+    <%= button_to "Cancel Account", cancel_registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: 'btn btn-danger' %>
   </div>
 </div>

--- a/app/views/registrations/_form_attributes.html.erb
+++ b/app/views/registrations/_form_attributes.html.erb
@@ -33,9 +33,9 @@
   <div class="span12">
     <fieldset class="required">
       <legend>
-        Attach your profile image
+        Attach <%= current_user.manager? ? User.find(params[:id]).name + "'s" : 'your' %> profile image
       </legend>
-      <%= f.input :files, as: :file, label: 'Upload your file' %>
+      <%= f.input :files, as: :file, label: 'Upload the file' %>
     </fieldset>
   </div>
 </div>

--- a/app/views/registrations/_form_password_management.html.erb
+++ b/app/views/registrations/_form_password_management.html.erb
@@ -1,20 +1,22 @@
 <div class="row">
 
   <fieldset class="span12">
-    <legend>Change Your Password</legend>
+    <legend>Change <%= current_user.manager? ? User.find(params[:id]).name + "'s" : 'Your' %> Password</legend>
 
     <%= f.input :password, label: "New password", input_html: { autocomplete: "off" } %>
-    <%= f.input :password_confirmation, label: "Repeat your new password", input_html: { autocomplete: "off" } %>
+    <%= f.input :password_confirmation, label: "Repeat the new password", input_html: { autocomplete: "off" } %>
   </fieldset>
 
 </div>
 
-<div class="row">
-  <fieldset class="span12">
-    <legend>Authorize Your Changes</legend>
-    <p><em>Enter your current password to confirm your changes</em></p>
+<% unless current_user.manager? %>
+  <div class="row">
+    <fieldset class="span12">
+      <legend>Authorize Your Changes</legend>
+      <p><em>Enter your current password to confirm your changes</em></p>
 
-    <%= f.input :current_password, required: true %>
+      <%= f.input :current_password, required: true %>
 
-  </fieldset>
-</div>
+   </fieldset>
+  </div>
+<% end %>

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -3,24 +3,27 @@
 <% end %>
 
 <%= simple_form_for(resource, :as => resource_name, :url => user_registration_path, :html => { :method => :put }) do |f| %>
-  <% if f.error_notification -%> 
+
+  <%= f.hidden_field :id %>
+
+  <% if f.error_notification -%>
     <div class="alert alert-error fade in">
       <strong>Wait don't go!</strong> There was a problem with your submission. Please review the errors below:
       <a class="close" data-dismiss="alert" href="#">&times;</a>
     </div>
   <% end -%>
 
-  <%= render partial: 'form_attributes', locals: {f: f} %>
+  <%= render partial: 'registrations/form_attributes', locals: {f: f} %>
 
-  <%= render partial: 'form_password_management', locals: {f: f} %>
+  <%= render partial: 'registrations/form_password_management', locals: {f: f} %>
 
   <div class="row">
     <div class="span12 form-actions">
-      <%= f.submit class: 'btn btn-primary', value: 'Update My Account' %>
+      <%= f.submit class: 'btn btn-primary', value: 'Update Account' %>
       <%= link_to 'Cancel', person_path(current_user.person), class: 'btn btn-link' %>
     </div>
   </div>
 
 <% end %>
 
-<%= render partial: 'form_account_deactivation', locals: { resource_name: resource_name } %>
+<%= render partial: 'registrations/form_account_deactivation', locals: { resource_name: resource_name } %>

--- a/lib/curate/rails/routes.rb
+++ b/lib/curate/rails/routes.rb
@@ -46,12 +46,13 @@ module ActionDispatch::Routing
 
       match "show/:id" => "common_objects#show", via: :get, as: "common_object"
       match "show/stub/:id" => "common_objects#show_stub_information", via: :get, as: "common_object_stub_information"
+      match 'users/:id/edit' => 'users#edit', via: :get, as: 'edit_user'
 
       #scope module: 'hydramata' do
       namespace :hydramata do
         resources 'groups'
       end
-      
+
     end
   end
 end

--- a/spec/features/manager_profile_workflow_spec.rb
+++ b/spec/features/manager_profile_workflow_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe 'manager profile workflow', FeatureSupport.options do
+
+  describe 'editing other user\'s profile as a manager' do
+    let(:manager_email) { 'manager@example.com' }
+    let(:manager_account) { FactoryGirl.create(:account, email: manager_email) }
+    let(:manager_user) { manager_account.user }
+    let(:account) { FactoryGirl.create(:account) }
+    let(:user) { account.user }
+
+    it 'successfully updates other user\'s attributes' do
+      login_as(manager_user)
+
+      visit edit_user_path(user.id)
+
+      new_name = 'Frodo Baggins'
+      new_pref = 'pref@example.com'
+      new_alt = 'alt@example.com'
+      new_dob = '1/2/1980'
+      new_gender = 'female'
+      new_title = 'student'
+      new_phone = '12345'
+      new_alt_phone = '67890'
+      new_webpage = 'www.example.com'
+      new_blog = 'blog.example.com'
+
+      within('form.edit_user') do
+        fill_in("user[name]", with: new_name)
+        fill_in("user[email]", with: new_pref)
+        fill_in("user[alternate_email]", with: new_alt)
+        fill_in("user[date_of_birth]", with: new_dob)
+        fill_in("user[gender]", with: new_gender)
+        fill_in("user[title]", with: new_title)
+        fill_in("user[campus_phone_number]", with: new_phone)
+        fill_in("user[alternate_phone_number]", with: new_alt_phone)
+        fill_in("user[personal_webpage]", with: new_webpage)
+        fill_in("user[blog]", with: new_blog)
+        click_button("Update")
+      end
+
+      msg = 'You updated your account successfully'
+      expect(page).to have_content msg
+
+      # Reload models
+      user.reload
+      user.person.reload
+
+      # Verify that everything got updated
+      user.name.should == new_name
+      user.email.should == new_pref
+      user.alternate_email.should == new_alt
+      user.date_of_birth.should == new_dob
+      user.gender.should == new_gender
+      user.title.should == new_title
+      user.campus_phone_number.should == new_phone
+      user.alternate_phone_number.should == new_alt_phone
+      user.personal_webpage.should == new_webpage
+      user.blog.should == new_blog
+    end
+  end
+end

--- a/spec/features/person_profile_spec.rb
+++ b/spec/features/person_profile_spec.rb
@@ -30,7 +30,7 @@ describe 'Profile for a Person: ' do
       within('form.edit_user') do
         fill_in("user[name]", with: 'Spider Man')
         fill_in("user[current_password]", with: password)
-        click_button "Update My Account"
+        click_button "Update Account"
       end
 
       visit catalog_index_path
@@ -82,9 +82,9 @@ describe 'Profile for a Person: ' do
     click_link "My Profile"
     click_link "Update Personal Information"
     within('form.edit_user') do
-      attach_file("Upload your file", image_file)
+      attach_file("Upload the file", image_file)
       fill_in("user[current_password]", with: password)
-      click_button "Update My Account"
+      click_button "Update Account"
     end
   end
 end

--- a/spec/features/user_profile_workflow_spec.rb
+++ b/spec/features/user_profile_workflow_spec.rb
@@ -105,7 +105,7 @@ describe 'user profile workflow', FeatureSupport.options do
     within('form.edit_user') do
       fill_in("user[email]", with: new_email)
       fill_in("user[current_password]", with: password)
-      click_button("Update My Account")
+      click_button("Update Account")
     end
     click_link("add-content")
 


### PR DESCRIPTION
Override the update method in
app/controllers/registrations_controller.rb so
managers can save profile changes without
entering a password.

Create app/controllers/users_controller.rb to
allow Devise to edit other users' profiles.

Add update_without_password and
update_user_without_user methods to
app/models/account.rb to allow proper updating
of user accounts.

Remove code from app/models/concerns/curate/ability.rb
that blocks person and profile update/edit/destroy
abilities from managers.

Tweak the manager_usernames method in
app/models/curate/user_behavior/base.rb so the
app does not crash if the yaml file is missing.

Edit several views to display proper buttons
and labels depeding on if they are a manager or not.
- app/views/curate/people/show.html.erb
- app/views/registrations/_form_account_deactivation.html.erb
- app/views/registrations/_form_attributes.html.erb
- app/views/registrations/_form_password_management.html.erb
- app/views/registrations/edit.html.erb

Add new /users/:id/edit route to
lib/curate/rails/routes.rb to allow managers to
edit another user's profile page.

Edit existing spec tests to adjust for changes
to buttons and other labels
- spec/features/person_profile_spec.rb
- spec/features/user_profile_workflow_spec.rb

HYDRASIR-302 #close
HYDRASIR-303 #close
HYDRASIR-313 #close
HYDRASIR-314 #close
