### PR TITLE
HYDRASIR-36 Display Creative Commons licenses or similar license terms t...

### DIFF
--- a/app/helpers/curate_helper.rb
+++ b/app/helpers/curate_helper.rb
@@ -50,7 +50,18 @@ module CurateHelper
     return markup if !subject.present? && !options[:include_empty]
     markup << %(<tr><th>#{label}</th>\n<td><ul class='tabular'>)
     [subject].flatten.compact.each do |value|
-      markup << %(<li class="attribute #{method_name}">#{h(value)}</li>\n)
+      if method_name == :rights
+        # Special treatment for license/rights.  A URL from the Sufia gem's config/sufia.rb is stored in the descMetadata of the
+        # curation_concern.  If that URL is valid in form, then it is used as a link.  If it is not valid, it is used as plain text.
+        parsedUri = URI.parse(value) rescue nil
+        if parsedUri.nil?
+          markup << %(<li class="attribute #{method_name}">#{h(value)}</li>\n)
+        else
+          markup << %(<li class="attribute #{method_name}"><a href=#{h(value)} target="_blank"> #{h(Sufia.config.cc_licenses_reverse[value])}</a></li>\n)
+        end
+      else
+        markup << %(<li class="attribute #{method_name}">#{h(value)}</li>\n)
+      end
     end
     markup << %(</ul></td></tr>)
     markup.html_safe

--- a/app/views/curation_concern/articles/_attributes.html.erb
+++ b/app/views/curation_concern/articles/_attributes.html.erb
@@ -18,5 +18,6 @@
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
   </tbody>
 </table>

--- a/app/views/curation_concern/documents/_attributes.html.erb
+++ b/app/views/curation_concern/documents/_attributes.html.erb
@@ -19,5 +19,6 @@
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
   </tbody>
 </table>

--- a/app/views/curation_concern/etds/_attributes.html.erb
+++ b/app/views/curation_concern/etds/_attributes.html.erb
@@ -16,5 +16,6 @@
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
   </tbody>
 </table>

--- a/app/views/curation_concern/generic_works/_attributes.html.erb
+++ b/app/views/curation_concern/generic_works/_attributes.html.erb
@@ -18,5 +18,6 @@
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
   </tbody>
 </table>

--- a/app/views/curation_concern/images/_attributes.html.erb
+++ b/app/views/curation_concern/images/_attributes.html.erb
@@ -17,5 +17,6 @@
     </td>
   </tr>
   <%= curation_concern_attribute_to_html(curation_concern, :embargo_release_date, "Embargo Release Date") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :rights, "Content License") %>
   </tbody>
 </table>


### PR DESCRIPTION
...hat submitter has selected
1. Added a line to the _attributes.html.erb partials to display the rights (i.e. content license).
2. Modified the curate_helper.rb curation_concern_attribute_to_html method to perform special handling of the :rights attribute.  That special handling involves coding an anchor link which opens in a separate tab if the :rights metadata is a url.  Otherwise, the text name of the license is displayed rather than a link.
