### PR TITLE
Add representative image to Collection

### DIFF
--- a/app/controllers/curate/collections_controller.rb
+++ b/app/controllers/curate/collections_controller.rb
@@ -55,8 +55,23 @@ class Curate::CollectionsController < ApplicationController
   before_filter :load_and_authorize_collection, only: [:add_member_form, :add_member]
 
   def new
-    @add_to_profile = params.delete(:add_to_profile)
     super
+    @add_to_profile = params.delete(:add_to_profile)
+  end
+
+  def create
+    super
+    @collection.file = params[ :collection ][ :file ] if params[ :collection ][ :file ]
+  end
+
+  def update
+    super
+    @collection.file = params[ :collection ][ :file ] if params[ :collection ][ :file ]
+  end
+
+  def index
+    super
+    redirect_to catalog_index_path(:'f[generic_type_sim][]' => 'Collection', works: 'mine')
   end
 
   def add_member_form

--- a/app/repository_models/collection.rb
+++ b/app/repository_models/collection.rb
@@ -2,8 +2,57 @@ class Collection < ActiveFedora::Base
   include Hydra::Collection
   include CurationConcern::CollectionModel
   include Hydra::Collections::Collectible
+  include Hydra::Derivatives
+
+  has_file_datastream :name => "content"
+  has_file_datastream :name => "medium"
+  has_file_datastream :name => "thumbnail"
+
+  attr_accessor :mime_type
+  attr_accessor :file
+
+  makes_derivatives :generate_derivatives
+
+  before_save :add_profile_image, :only => [ :create, :update ]
 
   def can_be_member_of_collection?(collection)
     collection == self ? false : true
+  end
+
+  def add_profile_image
+    if file
+      self.content.content = file
+      self.mime_type = file.content_type
+      generate_derivatives
+    end
+  end
+
+  def representative_image_url
+    generate_thumbnail_url if self.thumbnail.content.present?
+  end
+
+  def to_solr(solr_doc={}, opts={})
+    super(solr_doc, opts)
+    Solrizer.set_field(solr_doc, 'generic_type', 'Collection', :facetable)
+    solr_doc[Solrizer.solr_name('representative', :stored_searchable)] = self.representative
+    solr_doc[Solrizer.solr_name('representative_image_url', :stored_searchable)] = self.representative_image_url
+    solr_doc
+  end
+
+  def representative
+    to_param
+  end
+
+  private
+
+  def generate_derivatives
+    case mime_type
+    when 'image/png', 'image/jpeg', 'image/tiff'
+      transform_datastream :content, { medium: {size: "300x300>", datastream: 'medium'}, thumb: {size: "100x100>", datastream: 'thumbnail'} }
+    end
+  end
+
+  def generate_thumbnail_url
+    "/downloads/#{self.representative}?datastream_id=thumbnail"
   end
 end

--- a/app/views/curate/collections/_form.html.erb
+++ b/app/views/curate/collections/_form.html.erb
@@ -37,6 +37,16 @@
     </div>
   </div>
 
+  <div class="control-group string required collection_description">
+    <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: @collection} %>
+    <span class="control-label">
+      <%= f.label :avatar %>
+    </span>
+    <div class="controls">
+      <%= f.file_field :file, label: 'Upload the file' %>
+    </div>
+  </div>
+
   <%= render partial: 'form_permission', locals: {f: f} %>
 
   <%= hidden_collection_members %>

--- a/app/views/curate/collections/show.html.erb
+++ b/app/views/curate/collections/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, curation_concern_page_title(@collection) %>
 <% content_for :page_header do %>
+  <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: @collection} %>
   <h1> <%= @collection.title %> </h1>
 <% end %>
 <% if can? :edit, @collection %>

--- a/spec/controllers/curate/collections_controller_spec.rb
+++ b/spec/controllers/curate/collections_controller_spec.rb
@@ -25,7 +25,7 @@ describe Curate::CollectionsController do
     let!(:generic_work) { FactoryGirl.create(:generic_work, user: user) }
     it "should show a list of my collections" do
       get :index
-      expect(response).to be_successful
+      expect(response).to redirect_to( catalog_index_path(:'f[generic_type_sim][]' => 'Collection', works: 'mine') )
       expect(assigns[:document_list].map(&:id)).to include collection.pid
       expect(assigns[:document_list].map(&:id)).to_not include another_collection.pid
       expect(assigns[:document_list].map(&:id)).to_not include public_collection.pid

--- a/spec/features/collections_spec.rb
+++ b/spec/features/collections_spec.rb
@@ -6,15 +6,12 @@ describe "Showing and creating Collections" do
   it "should create them" do
     login_as(user)
     visit root_path
-    within 'nav' do
-      click_link "Collections"
-    end
-    click_button "Create Collection"
+    click_link "Add a Collection"
     expect(page).to have_content "Create a New Collection"
     fill_in 'collection_title', with: 'amalgamate members'
     fill_in 'collection_description', with: "I've collected a few related things together"
     click_button "Create Collection"
-    within 'table tbody' do
+    within '.search-result' do
       expect(page).to have_content 'amalgamate members'
     end
 
@@ -28,13 +25,32 @@ describe "Showing and creating Collections" do
     end
   end
 
+  it "should accept and display an optional image" do
+    login_as(user)
+    visit root_path
+    click_link "Add a Collection"
+    fill_in 'collection_title', with: 'amalgamate members'
+    fill_in 'collection_description', with: "I've collected a few related things together"
+    attach_file( 'collection_file', Rails.root.join('../fixtures/files/image.png') )
+    click_button "Create Collection"
+    expect( page ).to have_css( "img[src$='/downloads/#{user.collections.first.pid}?datastream_id=thumbnail']" )
+
+    visit collection_path( user.collections.first )
+    expect( page ).to have_css( "img[src$='/downloads/#{user.collections.first.pid}?datastream_id=thumbnail']" )
+
+    visit edit_collection_path( user.collections.first )
+    expect( page ).to have_css( "img[src$='/downloads/#{user.collections.first.pid}?datastream_id=thumbnail']" )
+
+    visit root_path
+    expect( page ).to have_css( "img[src$='/downloads/#{user.collections.first.pid}?datastream_id=thumbnail']" )
+  end
+
   it 'displays a friendly message if user has no collections yet' do
     login_as(user)
     visit collections_path
 
-    msg = 'You have no collections'
+    msg = 'No items found'
     expect(page).to have_content(msg)
-    expect(page).to have_button('Create Collection')
   end
 end
 


### PR DESCRIPTION
Add the required datastreams, methods and actions to enable users to
upload a representative image for each Collection. The Collection
image is displayed in the collections list and each individual
collection. The 'My Collections' button is re-directed to the
catalog, displaying the user's collections.
