### PR TITLE
Collapse search controls

### DIFF
--- a/app/assets/stylesheets/modules/search_results.css.scss
+++ b/app/assets/stylesheets/modules/search_results.css.scss
@@ -26,6 +26,10 @@
     top:0;
     width:80%;
   }
+
+  .modal {
+    text-align:left;
+  }
 }
 
 .search-result:first-child {

--- a/app/assets/stylesheets/modules/site_search.css.scss
+++ b/app/assets/stylesheets/modules/site_search.css.scss
@@ -27,6 +27,9 @@
 }
 
 .search-query-form {
+  margin-bottom:.3em;
+  padding-left:1em;
+
   .search-scope {
     display:block;
     line-height:1.5em;

--- a/app/views/application/_add_to_collection_gui.html.erb
+++ b/app/views/application/_add_to_collection_gui.html.erb
@@ -15,5 +15,7 @@
   </div>
 </div>
 
-<%= link_to 'Add to Collection', add_member_form_collections_path(collectible_id: collectible.pid), data: { toggle: "modal", target: ('#' + modal_id) }, method: :get, class: "add-to-collection #{button_class}", remote: true %>
+<%= link_to add_member_form_collections_path(collectible_id: collectible.pid), data: { toggle: "modal", target: ('#' + modal_id) }, method: :get, class: "add-to-collection #{button_class}", remote: true, title: "Add #{collectible.human_readable_type} to Collection"  do %>
+  <span class="icon icon-folder-open"></span>
+<% end %>
 

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -4,7 +4,9 @@
 
   <label class="search-scope">
     <%= radio_button_tag 'works', 'all', params['works'] != 'mine' %>
-    <span class="label-text">All Works</span>
+    <span class="label-text">All
+      <%= catalog_type %>
+    </span>
   </label>
 
   <label class="search-scope">

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -11,7 +11,7 @@
 
   <label class="search-scope">
     <%= radio_button_tag 'works', 'mine', params['works'] == 'mine' %>
-    <span class="label-text">Only My
+    <span class="label-text">My
       <%= catalog_type %>
     </span>
   </label>

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,17 +1,17 @@
-<h3>Show:</h3>
+<h3><%= t('sufia.search_facets.label') %></h3>
 <%= form_tag search_action_url, :method => :get, :class => 'search-query-form form-inline clearfix' do %>
   <%= search_as_hidden_fields(:omit_keys => [:qt, :page]).html_safe %>
 
   <label class="search-scope">
-    <%= radio_button_tag 'works', 'mine', params['works'] == 'mine' %>
-    <span class="label-text">Only My 
-      <%= catalog_type %>
-    </span>
+    <%= radio_button_tag 'works', 'all', params['works'] != 'mine' %>
+    <span class="label-text">All Works</span>
   </label>
 
   <label class="search-scope">
-    <%= radio_button_tag 'works', 'all', params['works'] != 'mine' %>
-    <span class="label-text">All Works</span>
+    <%= radio_button_tag 'works', 'mine', params['works'] == 'mine' %>
+    <span class="label-text">Only My
+      <%= catalog_type %>
+    </span>
   </label>
 
   <noscript>
@@ -20,8 +20,6 @@
     </button>
   </noscript>
 <% end %>
-
-<h3>Filter By:</h3>
 
 <ul class="nav nav-list slide-list" id="facets">
  <%= render_facet_partials %>

--- a/app/views/catalog/_index_partials/_identifier_and_action.html.erb
+++ b/app/views/catalog/_index_partials/_identifier_and_action.html.erb
@@ -8,12 +8,12 @@
     <%= render :partial => 'catalog/_index_partials/type_display', locals: {document: document} %>
   </div>
 
-  <div class="span6 search-result-link">
+  <div class="span7 search-result-link">
     <%# Minimize Fedora hits by using solr_doc rather than document %>
     <%= link_to title_link_text, title_link_target, :id => "src_copy_link_#{solr_doc.noid}" %>
   </div>
 
-  <div class="span4 search-result-actions">
+  <div class="span3 search-result-actions">
     <% if current_user -%>
       <% if can?( :edit, document ) && edit_path.present? %>
       <%= link_to(

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -10,3 +10,5 @@ en:
         q:
           label:        "Search Curate"
           placeholder:  "Type keywords in here"
+    search_facets:
+      label:            "View:"

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -79,7 +79,7 @@ describe "Search for a work" do
         click_button("keyword-search-submit")
       end
       href_link = add_member_form_collections_path(collectible_id: "#{Sufia.config.id_namespace}:#{noid}")
-      page.should have_link("Add to Collection", href: href_link)
+      page.should have_link("Add Image to Collection", href: href_link)
     end
   end
 

--- a/spec/views/application/_add_to_collection_gui.html.erb_spec.rb
+++ b/spec/views/application/_add_to_collection_gui.html.erb_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe 'application/add_to_collection_gui' do
-  let(:document)        { double(title: 'A Document',        pid: 'sufia:vwxyz', noid: 'vwxyz') }
-  let(:profile)         { double(title: 'Your Profile',      pid: 'sufia:abcde', noid: 'abcde') }
-  let(:collection)      { double(title: 'A Collection',      pid: 'sufia:12345', noid: '12345') }
-  let(:profile_section) { double(title: 'A Profile Section', pid: 'sufia:56789', noid: '56789') }
+  let(:document)        { double(title: 'A Document',        pid: 'sufia:vwxyz', noid: 'vwxyz', human_readable_type: 'Document'  ) }
+  let(:profile)         { double(title: 'Your Profile',      pid: 'sufia:abcde', noid: 'abcde', human_readable_type: 'Profile'   ) }
+  let(:collection)      { double(title: 'A Collection',      pid: 'sufia:12345', noid: '12345', human_readable_type: 'Collection') }
+  let(:profile_section) { double(title: 'A Profile Section', pid: 'sufia:56789', noid: '56789', human_readable_type: 'Collection') }
 
   context 'with collections and no profile sections' do
     before do
@@ -19,7 +19,7 @@ describe 'application/add_to_collection_gui' do
       expect(rendered).to include('Your Collections')
       expect(rendered).to include(collection.pid)
       expect(rendered).to_not include('Profile Sections')
-      expect(rendered).to have_link('Add to Collection', add_member_form_collections_path(collectible_id: document.pid))
+      expect(rendered).to have_link("Add #{document.human_readable_type} to Collection", add_member_form_collections_path(collectible_id: document.pid))
     end
   end
 
@@ -37,7 +37,7 @@ describe 'application/add_to_collection_gui' do
       expect(rendered).to include(profile.pid)
       expect(rendered).to include('Profile Sections')
       expect(rendered).to include(profile_section.pid)
-      expect(rendered).to have_link('Add to Collection', add_member_form_collections_path(collectible_id: document.pid))
+      expect(rendered).to have_link("Add #{document.human_readable_type} to Collection", add_member_form_collections_path(collectible_id: document.pid))
     end
   end
 
@@ -53,7 +53,7 @@ describe 'application/add_to_collection_gui' do
     it 'displays add link; includes no profile or collections' do
       expect(rendered).to_not include('Your Collections')
       expect(rendered).to_not include('Profile Sections')
-      expect(rendered).to have_link('Add to Collection', add_member_form_collections_path(collectible_id: document.pid))
+      expect(rendered).to have_link("Add #{document.human_readable_type} to Collection", add_member_form_collections_path(collectible_id: document.pid))
     end
   end
 end


### PR DESCRIPTION
This also simplifies the item-level controls in the search result view.
