### PR TITLE
Remove embargo date when object is not embargoed

### DIFF
--- a/app/repository_models/curation_concern/embargoable.rb
+++ b/app/repository_models/curation_concern/embargoable.rb
@@ -9,9 +9,9 @@ module CurationConcern
     module VisibilityOverride
       def visibility= value
         if value == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
-          @embargoed = true
           super(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
         else
+          self.embargo_release_date = nil
           super(value)
         end
       end
@@ -44,16 +44,20 @@ module CurationConcern
 
 
     def write_embargo_release_date
-      embargoable_persistence_container.embargo_release_date = @embargoed ? @embargo_release_date : nil
+      if defined?(@embargo_release_date)
+        embargoable_persistence_container.embargo_release_date = @embargo_release_date
+      end
       true
     end
     protected :write_embargo_release_date
 
     def embargo_release_date=(value)
-      @embargo_release_date = begin
-        value.present? ? value.to_date : nil
-      rescue NoMethodError, ArgumentError
-        value
+      unless defined?(@embargo_release_date) && @embargo_release_date.nil?
+        @embargo_release_date = begin
+          value.present? ? value.to_date : nil
+        rescue NoMethodError, ArgumentError
+          value
+        end
       end
     end
 

--- a/app/repository_models/curation_concern/embargoable.rb
+++ b/app/repository_models/curation_concern/embargoable.rb
@@ -9,9 +9,9 @@ module CurationConcern
     module VisibilityOverride
       def visibility= value
         if value == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
+          @embargoed = true
           super(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
         else
-          self.embargo_release_date = nil
           super(value)
         end
       end
@@ -44,9 +44,7 @@ module CurationConcern
 
 
     def write_embargo_release_date
-      if defined?(@embargo_release_date)
-        embargoable_persistence_container.embargo_release_date = @embargo_release_date
-      end
+      embargoable_persistence_container.embargo_release_date = @embargoed ? @embargo_release_date : nil
       true
     end
     protected :write_embargo_release_date

--- a/spec/repository_models/dataset_spec.rb
+++ b/spec/repository_models/dataset_spec.rb
@@ -4,12 +4,18 @@ describe Dataset do
   subject {  FactoryGirl.build(:dataset) }
 
   it_behaves_like 'is_a_curation_concern_model'
-  it_behaves_like 'with_access_rights'
   it_behaves_like 'with_related_works'
   it_behaves_like 'is_embargoable'
   it_behaves_like 'has_dc_metadata'
   it_behaves_like 'has_common_solr_fields'
 
   it { should have_unique_field(:available) }
+
+end
+
+describe Dataset do
+  subject { Dataset.new }
+
+  it_behaves_like 'with_access_rights'
 
 end

--- a/spec/repository_models/document_spec.rb
+++ b/spec/repository_models/document_spec.rb
@@ -7,7 +7,6 @@ describe Document do
   it { should have_unique_field(:type) }
 
   it_behaves_like 'is_a_curation_concern_model'
-  it_behaves_like 'with_access_rights'
   it_behaves_like 'with_related_works'
   it_behaves_like 'is_embargoable'
   it_behaves_like 'has_dc_metadata'
@@ -35,5 +34,12 @@ describe Document do
       expect(doc.errors[:type]).to_not be_present
     end
   end
+
+end
+
+describe Document do
+  subject { Document.new }
+
+  it_behaves_like 'with_access_rights'
 
 end

--- a/spec/repository_models/etd_spec.rb
+++ b/spec/repository_models/etd_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Etd do
   subject { FactoryGirl.build(:etd) }
 
-  it_behaves_like 'with_access_rights'
   it_behaves_like 'with_related_works'
   it_behaves_like 'is_embargoable'
   it_behaves_like 'has_common_solr_fields'
@@ -18,5 +17,12 @@ describe Etd do
   it { should have_multivalue_field(:subject) }
   it { should have_multivalue_field(:publisher) }
   it { should have_multivalue_field(:language) }
+
+end
+
+describe Etd do
+  subject { Etd.new }
+
+  it_behaves_like 'with_access_rights'
 
 end

--- a/spec/repository_models/generic_work_spec.rb
+++ b/spec/repository_models/generic_work_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe GenericWork do
   subject { FactoryGirl.build(:generic_work) }
 
-  it_behaves_like 'with_access_rights'
   it_behaves_like 'with_related_works'
   it_behaves_like 'is_embargoable'
   it_behaves_like 'has_dc_metadata'
@@ -36,7 +35,7 @@ describe GenericWork do
   end
 
   describe 'Embargo' do
-    let!(:work) { FactoryGirl.create(:generic_work, title: 'Embargo Work') }
+    let!(:work) { FactoryGirl.create(:generic_work, title: 'Embargo Work', visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) }
      
     it "should not be under embargo by default" do
       expect(work).to_not be_under_embargo
@@ -160,4 +159,11 @@ describe GenericWork do
       end
     end
   end
+end
+
+describe GenericWork do
+  subject { GenericWork.new }
+
+  it_behaves_like 'with_access_rights'
+
 end

--- a/spec/workers/visibility_copy_worker_spec.rb
+++ b/spec/workers/visibility_copy_worker_spec.rb
@@ -20,7 +20,7 @@ describe VisibilityCopyWorker do
 
   describe "an embargoed work" do
     let(:embargo_date) { 2.days.from_now }
-    let(:work) { FactoryGirl.create(:generic_work_with_files, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, embargo_release_date: embargo_date) }
+    let(:work) { FactoryGirl.create(:generic_work_with_files, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, embargo_release_date: embargo_date) }
     subject { VisibilityCopyWorker.new(work.id) }
 
     it "should have no content at the outset" do


### PR DESCRIPTION
The change in hydra-access-controls that was needed for this fix has been merged into hydra-head.  So I'm opening a PR for the related changes in Curate.  This will allow an object with an embargo date to be switched to different access rights with no release date.
