### PR TITLE
Filter out collection and person in "More Work Types"

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -17,7 +17,7 @@ class CatalogController < ApplicationController
   CatalogController.solr_search_params_logic += [:add_access_controls_to_solr_params]
   # This filters out objects that you want to exclude from search results, like FileAssets
   CatalogController.solr_search_params_logic += [:exclude_unwanted_models]
-
+  CatalogController.solr_search_params_logic += [:show_only_works]
   before_filter :agreed_to_terms_of_service!
 
   skip_before_filter :default_html_head
@@ -25,16 +25,6 @@ class CatalogController < ApplicationController
   def index
     collection_options
     super
-  end
-
-  def self.human_readable_type_hash
-    { :article_facet => { :label => 'Articles', :fq => "active_fedora_model_ssi:Article" },
-      :dataset_facet => { :label => 'Datasets', :fq => "active_fedora_model_ssi:Dataset" },
-      :document_facet=> { :label => 'Document', :fq => "active_fedora_model_ssi:Document" },
-      :etd_facet=> { :label => 'ETD', :fq => "active_fedora_model_ssi:Etd" },
-      :generic_file_facet=> { :label => 'Generic Files', :fq => "active_fedora_model_ssi:GenericFile" },
-      :generic_work_facet=> { :label => 'Generic Works', :fq => "active_fedora_model_ssi:GenericWork" },
-      :image_facet => { :label => 'Images', :fq => "active_fedora_model_ssi:Image"}}
   end
 
   def self.uploaded_field
@@ -78,7 +68,7 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
-    config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type of Work", :query => human_readable_type_hash, limit: 5
+    config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type of Work", limit: 5
     config.add_facet_field solr_name(:desc_metadata__creator, :facetable), label: "Creator", helper_method: :creator_name_from_pid, limit: 5
 
     config.add_facet_field solr_name("desc_metadata__tag", :facetable), label: "Keyword", limit: 5
@@ -392,6 +382,16 @@ class CatalogController < ApplicationController
       solr_parameters[:fq] << "-has_model_ssim:\"info:fedora/afmodel:LinkedResource\""
       solr_parameters[:fq] << "-has_model_ssim:\"info:fedora/afmodel:Hydramata_Group\""
       return solr_parameters
+    end
+
+    #Excludes collection and person only when trying to filter by work.
+    # This is included as part of blacklight search solr params logic
+    def show_only_works(solr_parameters, user_parameters)
+      if params.has_key?(:f) and params[:f].to_a.flatten == ["generic_type_sim","Work"]
+        solr_parameters[:fq] ||= []
+        solr_parameters[:fq] << "-has_model_ssim:\"info:fedora/afmodel:Collection\""
+        solr_parameters[:fq] << "-has_model_ssim:\"info:fedora/afmodel:Person\""
+      end
     end
 
     def depositor


### PR DESCRIPTION
This pull request fixs both HYDRASIR-272 and HYDRASIR-319

Reverting changes by HYDRASIR-272 since it resulted in bug when trying to view by work type.
Added method to blacklight solr_search_params_logic which is  applied only during work_type file. This solution works better since it remove collection and person only from work filter and available for querying if needed in other places
