### PR TITLE
HYDRASIR-394 Profile sections should not have thumbnails/avatar

### DIFF
--- a/app/views/curate/collections/_form.html.erb
+++ b/app/views/curate/collections/_form.html.erb
@@ -37,15 +37,21 @@
     </div>
   </div>
 
-  <div class="control-group string required collection_description">
-    <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: @collection} %>
-    <span class="control-label">
-      <%= f.label :avatar %>
-    </span>
-    <div class="controls">
-      <%= f.file_field :file, label: 'Upload the file' %>
+  <%# We do not want to display the avatar control if this collection is a profile section. %>
+  <%# There are 2 situations where this partial is rendered, 1) when the section is created %>
+  <%# 2) when the section is edited.  We must check for both those situations: 1) is_a? and %>
+  <%# 2) include?, respectively.                                                            %>
+  <% if !@collection.is_a?(ProfileSection) && !ActiveFedora::ContentModel.known_models_for(@collection).include?(ProfileSection) %>
+    <div class="control-group string required collection_description">
+      <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: @collection} %>
+      <span class="control-label">
+        <%= f.label :avatar %>
+      </span>
+      <div class="controls">
+        <%= f.file_field :file, label: 'Upload the file' %>
+      </div>
     </div>
-  </div>
+  <% end %>
 
   <%= render partial: 'form_permission', locals: {f: f} %>
 

--- a/app/views/curate/collections/show.html.erb
+++ b/app/views/curate/collections/show.html.erb
@@ -1,6 +1,9 @@
 <% content_for :page_title, curation_concern_page_title(@collection) %>
 <% content_for :page_header do %>
-  <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: @collection} %>
+  <%# We need to know if this collection is a user profile section collection.  If it is, then no avatar is displayed. %>
+  <% if !ActiveFedora::ContentModel.known_models_for(@collection).include?(ProfileSection) %>
+    <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: @collection} %>
+  <% end %>
   <h1> <%= @collection.title %> </h1>
 <% end %>
 <% if can? :edit, @collection %>

--- a/spec/features/adding_section_to_profile.rb
+++ b/spec/features/adding_section_to_profile.rb
@@ -10,11 +10,14 @@ describe 'Adding a section to a Profile: ' do
     it 'adds a section to their profile' do
       visit person_path(user.person)
       click_on 'Add a Section to my Profile'
+      page.should_not have_selector('#collection_file')
       within('#new_profile_section') do
         fill_in('profile_section_title', with: 'New Collection on Bilbo')
         click_on 'Create Profile section'
       end
       page.should have_content('New Collection on Bilbo')
+      click_on 'Edit'
+      page.should_not have_selector('#collection_file')
     end
   end
 


### PR DESCRIPTION
Modified new/edit collection form to not show avatar controls when the collection is a ProfileSection.
Modified the show form for collection to not show the avatar for a ProfileSection.
Added spec test to verify avatar control is not present when creating/editing a profile section.
