### PR TITLE
HYDRASIR-293 As a proxy, I should not be listed as a contributor

### DIFF
--- a/app/assets/javascripts/curate.js
+++ b/app/assets/javascripts/curate.js
@@ -33,6 +33,7 @@
 //= require curate/proxy_rights
 //= require curate/facet_mine
 //= require curate/accept_contributor_agreement
+//= require curate/proxy_submission
 //= require handlebars
 //= require browse_everything_implement
 

--- a/app/assets/javascripts/curate/proxy_submission.js
+++ b/app/assets/javascripts/curate/proxy_submission.js
@@ -1,0 +1,23 @@
+/**
+ * This Javascript/JQuery method is used for the population of the contributor field
+ * when a proxy user is making a deposit on behalf of someone else.  The method gets the selected
+ * person on behalf of whom the proxy person is making the deposit and places that person's name in
+ * a Contributor field and clicks the contributor Add button.
+ */
+function updateContributors(){
+
+    // Get the selected owner name from the owner control.
+    // If it is 'Myself', then pluck the name from the display name on the dropdown menu in the title bar of the page.
+    // If 'nothing' was selected, do nothing and return.
+
+    var ownerName = $("[id*='_owner'] option:selected").text();
+    if (ownerName == 'Myself') {
+        ownerName = $(".user-display-name").text().trim();
+    }
+    else if (ownerName === "") { return; }
+
+    // Put that name into the "Add" Contributor control and force a click of the Add button.
+    // Note that the last Contributor control is always the one into which a new user is entered.
+    $("#contributors .controls .listing .ui-autocomplete-input").last().val(ownerName);
+    $("#contributors .controls .listing .field-controls .add").click();
+}

--- a/app/controllers/curation_concern/generic_works_controller.rb
+++ b/app/controllers/curation_concern/generic_works_controller.rb
@@ -28,8 +28,10 @@ class CurationConcern::GenericWorksController < CurationConcern::BaseController
   protected :after_create_response
 
   # Override setup_form in concrete controllers to get the form ready for display
-  def setup_form 
-    curation_concern.contributors << current_user.person if curation_concern.contributors.blank?
+  def setup_form
+    # Contributors list is automatically populated with the current user if there are no contributors (i.e. a new work)
+    # and if the current user is NOT a proxy for anyone.
+    curation_concern.contributors << current_user.person if curation_concern.contributors.blank? && !current_user.can_make_deposits_for.any?
     curation_concern.contributors << Person.new
     curation_concern.editors << current_user.person if curation_concern.editors.blank?
     curation_concern.editors.build

--- a/app/helpers/curate_helper.rb
+++ b/app/helpers/curate_helper.rb
@@ -107,6 +107,29 @@ module CurateHelper
     return edit_polymorphic_path(polymorphic_path_args(asset))
   end
 
+  # This converts a collection of objects to a 2 dimensional array having keys accessed via the key_method on the objects
+  # and the values accessed via the value_method on the objects.
+  # key_method and value_method are strings which are the names of the methods or accessors or attributes by
+  # which the value of the key and the value of the array value can be acquired for each of the objects.  These
+  # values for the key and the value are placed into the returned array.
+  # EXAMPLE:  Oh is class which has methods a, b, c, d, e on it (Oh.a, Oh.b, etc.).  You want an array of
+  #           a collection of Ohs.  The array would contain the value of b as the key and the value of e as the corresponding value.
+  #           The collection of Ohs is in the variable ohList.
+  #           ohArray = objects_to_array(ohList, 'b', 'e')
+  def objects_to_array(collection, key_method, value_method)
+    returnArray = collection.map do |element|
+      [get_value_for(element, key_method), get_value_for(element, value_method)]
+    end
+  end
+
+  # This is a private helper method which given an item (an object), retrieves the value of some member on it by way of
+  # what is specified in the by_means_of parameter.  by_means_of is the string name of a method, an accessor, an
+  # attribute, or other mechanism which can access that information on the item.
+  def get_value_for(item, by_means_of)
+    by_means_of.respond_to?(:call) ? by_means_of.call(item) : item.send(by_means_of)
+  end
+  private :get_value_for
+
 
   def extract_dom_label_class_and_link_title(document)
     hash = document.stringify_keys

--- a/app/views/curation_concern/base/_on_behalf_of.html.erb
+++ b/app/views/curation_concern/base/_on_behalf_of.html.erb
@@ -1,18 +1,31 @@
 <% if current_user.can_make_deposits_for.any? %>
   <% if curation_concern.new_record? %>
-    <fieldset class="row with-footroom">
+
+    <div class="row with-footroom">
       <div class="span12">
-        <legend>
-          Ownership
-          <small>Are you depositing your own <%= curation_concern.human_readable_type %> or depositing it on behalf of someone else?</small>
-        </legend>
+
+        <fieldset id="set-owner">
+
+          <legend>
+            Ownership
+            <small>Are you depositing your own <%= curation_concern.human_readable_type %> or depositing it on behalf of someone else?</small>
+          </legend>
+
+            <%= f.input :owner,
+                        as: :select,
+                        collection: objects_to_array(current_user.can_make_deposits_for, 'name', 'user_key').unshift(['Myself', current_user.user_key]),
+                        input_html: { class: 'input-xxlarge', onChange: 'updateContributors();' },
+                        label: "Create this #{curation_concern.human_readable_type} on behalf of:",
+                        required: true
+            %>
+
+        </fieldset>
+
       </div>
-      <div class="controls span12" id="delegate-actions">
-        <%= f.label :owner, "Create this #{curation_concern.human_readable_type} on behalf of:" %>
-        <%= f.select :owner, options_from_collection_for_select(current_user.can_make_deposits_for, 'user_key', 'name'), prompt: 'Myself' %>
-      </div>
-    </fieldset>
+    </div>
+
   <% elsif !(curation_concern.owner == current_user.user_key) %>
+
     <fieldset class="row with-footroom">
       <div class="span12">
         <legend>
@@ -25,5 +38,6 @@
         </section>
       </div>
     </fieldset>
+
   <% end %>
 <% end %>

--- a/spec/features/proxy_deposit_spec.rb
+++ b/spec/features/proxy_deposit_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe 'Proxy Deposit' do
+  let(:user) { FactoryGirl.create(:user, name: 'Im A. User') }
+  let(:proxy) { FactoryGirl.create(:user, name: 'Me A. Proxy') }
+  let(:user_person) { FactoryGirl.create(:account, user: user)}
+  let(:proxy_person) { FactoryGirl.create(:account, user: proxy)}
+  before do
+    user.can_receive_deposits_from << proxy
+  end
+
+  it 'defaults to blank for owner, with Myself and user name' do
+    login_as(proxy)
+    visit root_path
+    click_link "add-content"
+    classify_what_you_are_uploading 'Article'
+
+    within '#new_article' do
+      expect(page).to have_selector('#article_owner', text: "")
+      expect(page).to have_selector('#article_owner', text: "Myself")
+      expect(page).to have_selector('#article_owner', text: user.name)
+      expect(page).to have_selector("#article_contributors_attributes_0_name", text: "")
+    end
+  end
+
+  it 'auto-selects user as contributor when user is selected as owner' do
+    login_as(proxy)
+    visit root_path
+    click_link "add-content"
+    classify_what_you_are_uploading 'Article'
+
+    within '#new_article' do
+      select user.name, :from => 'article_owner'
+      fill_in "Title", with: "My article"
+      fill_in "External link", with: "http://www.youtube.com/watch?v=oHg5SJYRHA0"
+      choose('Visible to the world.')
+      check("I have read and accept the contributor license agreement")
+      click_button("Create Article")
+    end
+
+    page.should have_content(user.name)
+  end
+
+  it 'auto-selects proxy as contributor when Myself is selected as owner' do
+    login_as(proxy)
+    visit root_path
+    click_link "add-content"
+    classify_what_you_are_uploading 'Article'
+
+    within '#new_article' do
+      select 'Myself', :from => 'article_owner'
+      fill_in "Title", with: "My article"
+      fill_in "External link", with: "http://www.youtube.com/watch?v=oHg5SJYRHA0"
+      choose('Visible to the world.')
+      check("I have read and accept the contributor license agreement")
+      click_button("Create Article")
+    end
+
+    page.should have_content(proxy.name)
+  end
+
+end


### PR DESCRIPTION
1. The proxy, i.e. current user, is not automatically added as a contributor.
2. 'Ownership' field does not default to 'Myself', but instead defaults to blank.
3. 'Ownership' field is now required so user must make a selection.
4. Hook up the "Ownership" field with javascript/jquery which will update the new contributor control and force a click of its Add button to add that
   person as a contributor.
5. Add proxy_deposit_spec.rb spec test file.

NOTE:  These changes require HYDRASIR-275 to be complete.
