### PR TITLE
HYDRASIR-404 A Profile Section should always be open/public

### DIFF
--- a/app/repository_models/profile_section.rb
+++ b/app/repository_models/profile_section.rb
@@ -6,4 +6,8 @@ class ProfileSection < ActiveFedora::Base
   def can_be_member_of_collection?(collection)
     collection.is_a?(Profile)
   end
+
+  def visibility
+    return Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+  end
 end

--- a/app/views/curate/collections/_form.html.erb
+++ b/app/views/curate/collections/_form.html.erb
@@ -37,10 +37,9 @@
     </div>
   </div>
 
-  <%# We do not want to display the avatar control if this collection is a profile section. %>
-  <%# There are 2 situations where this partial is rendered, 1) when the section is created %>
-  <%# 2) when the section is edited.  We must check for both those situations: 1) is_a? and %>
-  <%# 2) include?, respectively.                                                            %>
+  <%# We want to display neither the avatar control nor the access permission controls if this collection is a profile section. %>
+  <%# There are 2 situations where this partial is rendered, 1) when the section is created 2) when the section is edited.      %>
+  <%# We must check for both those situations: 1) is_a? and 2) include?, respectively.                                          %>
   <% if !@collection.is_a?(ProfileSection) && !ActiveFedora::ContentModel.known_models_for(@collection).include?(ProfileSection) %>
     <div class="control-group string required collection_description">
       <%= render :partial => 'catalog/_index_partials/thumbnail_display', locals: {document: @collection} %>
@@ -51,9 +50,9 @@
         <%= f.file_field :file, label: 'Upload the file' %>
       </div>
     </div>
-  <% end %>
 
-  <%= render partial: 'form_permission', locals: {f: f} %>
+    <%= render partial: 'form_permission', locals: {f: f} %>
+  <% end %>
 
   <%= hidden_collection_members %>
 

--- a/spec/controllers/curate/collections_controller_spec.rb
+++ b/spec/controllers/curate/collections_controller_spec.rb
@@ -56,6 +56,7 @@ describe Curate::CollectionsController do
       }.to_not change{Collection.count}
 
       reloaded_profile.members.should == [assigns(:collection)]
+      assigns(:collection).visibility.should == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
     it "gracefully recovery if no profile exists" do

--- a/spec/features/adding_section_to_profile.rb
+++ b/spec/features/adding_section_to_profile.rb
@@ -11,6 +11,7 @@ describe 'Adding a section to a Profile: ' do
       visit person_path(user.person)
       click_on 'Add a Section to my Profile'
       page.should_not have_selector('#collection_file')
+      page.should_not have_content "Access Rights"
       within('#new_profile_section') do
         fill_in('profile_section_title', with: 'New Collection on Bilbo')
         click_on 'Create Profile section'
@@ -18,6 +19,7 @@ describe 'Adding a section to a Profile: ' do
       page.should have_content('New Collection on Bilbo')
       click_on 'Edit'
       page.should_not have_selector('#collection_file')
+      page.should_not have_content "Access Rights"
     end
   end
 

--- a/spec/features/collections_spec.rb
+++ b/spec/features/collections_spec.rb
@@ -10,6 +10,7 @@ describe "Showing and creating Collections" do
     expect(page).to have_content "Create a New Collection"
     fill_in 'collection_title', with: 'amalgamate members'
     fill_in 'collection_description', with: "I've collected a few related things together"
+    expect(page).to have_content "Access Rights"
     click_button "Create Collection"
     within '.search-result' do
       expect(page).to have_content 'amalgamate members'


### PR DESCRIPTION
1. ProfileSection class overrides visibility to return public access right by default.
2. No Access Rights section is shown on the new/edit profile section form.
3. Updated existing specs to test for both of the above changes.
