### PR TITLE
Allow repository manager to see embargoed content

### DIFF
--- a/app/helpers/hydramata/solr_helper.rb
+++ b/app/helpers/hydramata/solr_helper.rb
@@ -7,37 +7,39 @@ module Hydramata::SolrHelper
   # Enforce embargo for all Solr queries
   def enforce_embargo(solr_parameters, user_parameters)
     solr_parameters[:fq] ||= []
-    
+
     # Include Solr docs where the embargo is not in effect,
     # OR the embargo is in effect and the user belongs to a group with access,
     # OR the embargo is in effect and the current user is depositor
 
     # logged-in
     if current_user.present?
-      
-      group_query = ""
-      
-      # Used to build the group access portion of the query
-      current_user.person.groups.each_with_index {|group, index|
-        group.title.gsub!(" ", "\\\\ ")
-        
-        if index != 0
-          group_query << "OR "
+
+      unless current_user.manager?
+        group_query = ""
+
+        # Used to build the group access portion of the query
+        current_user.person.groups.each_with_index {|group, index|
+          group.title.gsub!(" ", "\\\\ ")
+
+          if index != 0
+            group_query << "OR "
+          end
+
+          group_query << "discover_access_group_ssim:#{group.title} OR read_access_group_ssim:#{group.title} OR edit_access_group_ssim:#{group.title} "
+
+        }
+
+        if group_query.present?
+          embargo_query = "(*:* NOT embargo_release_date_dtsi:[NOW TO *]) OR (embargo_release_date_dtsi:[NOW TO *] AND (#{group_query})) OR (embargo_release_date_dtsi:[NOW TO *] AND depositor_tesim:#{current_user.email})"
+
+        # User doesn't have groups to query
+        else
+          embargo_query = "(*:* NOT embargo_release_date_dtsi:[NOW TO *]) OR (embargo_release_date_dtsi:[NOW TO *] AND depositor_tesim:#{current_user.email})"
+
         end
-
-        group_query << "discover_access_group_ssim:#{group.title} OR read_access_group_ssim:#{group.title} OR edit_access_group_ssim:#{group.title} "
-  
-      }
-      
-      if group_query.present?
-        embargo_query = "(*:* NOT embargo_release_date_dtsi:[NOW TO *]) OR (embargo_release_date_dtsi:[NOW TO *] AND (#{group_query})) OR (embargo_release_date_dtsi:[NOW TO *] AND depositor_tesim:#{current_user.email})"
-
-      # User doesn't have groups to query
-      else
-        embargo_query = "(*:* NOT embargo_release_date_dtsi:[NOW TO *]) OR (embargo_release_date_dtsi:[NOW TO *] AND depositor_tesim:#{current_user.email})"
-     
       end
-      
+
     # not logged-in
     else
       embargo_query = "(*:* NOT embargo_release_date_dtsi:[NOW TO *])"

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -55,6 +55,11 @@ describe CatalogController do
     let!(:work1) {
       FactoryGirl.create_curation_concern(:generic_work, creating_user, { visibility: visibility })
     }
+    let(:embargo) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    let(:embargo_release_date) { Date.tomorrow.to_s }
+    let!(:work2) {
+      FactoryGirl.create_curation_concern(:generic_work, creating_user, { visibility: embargo, embargo_release_date: embargo_release_date })
+    }
     before do
       sign_in manager_user
     end
@@ -62,7 +67,12 @@ describe CatalogController do
       it "should return other users' private works" do
         get 'index', 'f' => {'generic_type_sim' => 'Work'}
         response.should be_successful
-        assigns(:document_list).map(&:id).should == [work1.id]
+        assigns(:document_list).map(&:id).should include(work1.id)
+      end
+      it "should return other users' embargoed works" do
+        get 'index', 'f' => {'generic_type_sim' => 'Work'}
+        response.should be_successful
+        assigns(:document_list).map(&:id).should include(work2.id)
       end
     end
 


### PR DESCRIPTION
Edited app/helpers/hydramata/solr_helper.rb to not add embargo to
the solr query if the current user is a repository manager.

Added a new test to verify that a repository manager can discover
another user's embargoed work.

Note: Managers could already see the show pages for embargoed
works.  This sub-task only needed to fix discoverability.

HYDRASIR-355 #close
