### PR TITLE
Not looking up User in view

### DIFF
--- a/app/views/registrations/_form_attributes.html.erb
+++ b/app/views/registrations/_form_attributes.html.erb
@@ -31,7 +31,7 @@
   <div class="span12">
     <fieldset class="required">
       <legend>
-        Attach <%= current_user.manager? ? User.find(params[:id]).name + "'s" : 'your' %> profile image
+        Attach <%= current_user.manager? ? "#{f.object.name}'s" : 'your' %> profile image
       </legend>
       <%= f.input :files, as: :file, label: 'Upload the file' %>
     </fieldset>

--- a/app/views/registrations/_form_password_management.html.erb
+++ b/app/views/registrations/_form_password_management.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
 
   <fieldset class="span12">
-    <legend>Change <%= current_user.manager? ? User.find(params[:id]).name + "'s" : 'Your' %> Password</legend>
+    <legend>Change <%= current_user.manager? ? f.object.name + "'s" : 'Your' %> Password</legend>
 
     <%= f.input :password, label: "New password", input_html: { autocomplete: "off" } %>
     <%= f.input :password_confirmation, label: "Repeat the new password", input_html: { autocomplete: "off" } %>


### PR DESCRIPTION
Given that we already know the user we are editing, instead refer
to the object that is being edited (i.e. f.object is the user).

In the case of editing your own profile, devise's convention is to
have the route be /users/edit. This means that `params[:id]` is nil.

[skip ci]
