### PR TITLE
Added unit tests for embargo. Test coverage now includes testing search ...

### DIFF
--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+
 describe_options = {type: :feature}
 if ENV['JS']
   describe_options[:js] = true
@@ -16,6 +17,7 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
   end
 
   let(:another_user) { FactoryGirl.create(:user, agreed_to_terms_of_service: true) }
+  let(:another_person) { FactoryGirl.create(:person_with_user) }
   let(:prefix) { Time.now.strftime("%Y-%m-%d-%H-%M-%S-%L") }
   let(:initial_title) { "#{prefix} Something Special" }
   let(:initial_file_path) { __FILE__ }
@@ -58,6 +60,7 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
 
   describe 'with user who has already agreed to the terms of service' do
     let(:agreed_to_terms_of_service) { true }
+    let(:test_group_1) { FactoryGirl.create(:group, :title=>"Test Group 1")}
     it "displays the start uploading" do
       login_as(user)
       visit '/'
@@ -87,13 +90,25 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
     end
 
     it "a public item with future embargo is not visible today but is in the future" do
-      embargo_release_date = 2.days.from_now
       # Because the JS will transform an unexpected input entry to the real
       # today (browser's date), and I want timecop to help
+      embargo_release_date = 1.days.from_now
       embargo_release_date_formatted = embargo_release_date.strftime("%Y-%m-%d")
+      
+      # Make sure the title is unique
+      title = SecureRandom.uuid
+      
       login_as(user)
       visit new_curation_concern_generic_work_path
+      
+      # Timecop doesn't work for just changing the system date because Solr uses it's own system date for the embargo queries,
+      # and Active Fedora doesn't allow an embargo date in the past.
+      # Under embargo test steps: Set the embargo date to one day from now. Run tests to make sure object is under embargo.
+      # Out of embargo test steps: Go back to one week before today and set the embargo date to a day after that.
+      # Return to now. Run tests.
+
       create_generic_work(
+        "Title" => title,
         'Embargo Release Date' => embargo_release_date_formatted,
         'Visibility' => 'visibility_embargo',
         'Contributors' => 'Dante',
@@ -105,26 +120,89 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
 
 
       noid = page.current_path.split("/").last
+      
+      # The embargo'd object should show up in a search for the owner
+      search_catalog_for_title(title)
+      page.assert_selector('a', text: title)
+
+      # The owner should be able to see the embargo'd object's show view
+      visit("/concern/generic_works/#{noid}")
+      page.assert_no_selector('h1', text: "Unauthorized")
+
       logout
       
-       # An anonymous user should not be able to see the embargo'd object.
-      #visit("/show/#{noid}")
-      visit("/concern/generic_works/#{noid}")
-      page.assert_no_selector('h1', text: "Object Not Available")
-      
-      #visit("/show/#{noid}")
-      visit("/concern/generic_works/#{noid}")
-      
-      # Seconds are weeks
-      begin
-        Timecop.scale(60*60*24*7)
-        sleep(1)
-      ensure
-        Timecop.scale(1)
-      end
-      expect(Time.now > embargo_release_date).to be_true
+      # Assign the work to a group
+      work = ActiveFedora::Base.find("sufia:#{noid}", :cast => :true)
+      work.add_editor_group(test_group_1)
+      work.save!
+      #Assign a different user to the group
+      test_group_1.add_member(another_person)
+      test_group_1.save!
+      login_as(another_person.user)
 
+      # The embargo'd object should show up in a search for someone in a group that has access
+      search_catalog_for_title(title)
+      page.assert_selector('a', text: title)
+
+      # Someone in a group that has access should be able to see the embargo'd object's show view
+      visit("/concern/generic_works/#{noid}")
+      page.assert_no_selector('h1', text: "Unauthorized")
+
+      logout
+
+      # An anonymous user should not be able to see the embargo'd object in the search results.
+      search_catalog_for_title(title)
+      page.assert_no_selector('a', text: title)
+
+      # An anonymous user should not be able to see the embargo'd object's show view.
+      visit("/concern/generic_works/#{noid}")
+      page.assert_selector('h1', text: "Unauthorized")
+      
+      login_as(user)
+      
+      # Go back a 1/1/2014
+      new_time = Time.local(2014, 1, 1)
+      Timecop.travel(new_time) do
+        
+        # Set embargo date to one day from "now"
+        work.embargo_release_date = (Time.now + 1.day).strftime("%Y-%m-%d")
+        work.save!
+        
+        # Go back to now
+        Timecop.return
+
+        # The embargo'd object should still show up in a search for the owner
+        search_catalog_for_title(title)
+        page.assert_selector('a', text: title)
+      
+        # The owner should still be able to see the embargo'd object's show view
+        visit("/concern/generic_works/#{noid}")
+        page.assert_no_selector('h1', text: "Unauthorized")   
+      
+        logout
+
+        login_as(another_person.user)
+
+         # The embargo'd object should still show up in a search for someone in a group that has access
+        search_catalog_for_title(title)
+        page.assert_selector('a', text: title)
+      
+        # Someone in a group that has access should still be able to see the embargo'd object's show view
+        visit("/concern/generic_works/#{noid}")
+        page.assert_no_selector('h1', text: "Unauthorized") 
+
+        logout
+
+        # An anonymous user should now be able to see the embargo'd object in the search results.
+        search_catalog_for_title(title)
+        page.assert_selector('a', text: title)
+
+        # An anonymous user should now be able to see the embargo'd object's show view.
+        visit("/concern/generic_works/#{noid}")
+        page.assert_no_selector('h1', text: "Unauthorized")
+      end
     end
+
   end
 
   describe 'help request' do
@@ -345,4 +423,13 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
     visit path_to_other_persons_resource
     page.should_not have_content(updated_title)
   end
+
+  def search_catalog_for_title(title)
+    visit("/")
+    within(".search-form") do
+      fill_in("catalog_search", with: title)
+      click_on("keyword-search-submit")
+    end
+  end
+
 end


### PR DESCRIPTION
...and show view for owner, non-logged in user and a user in a group that has access to the work. The tests put a work in embargo and out of embargo."

Added tests to make sure search (Solr query) is correctly enforcing embargo

Added tests to make sure search (Solr query) is correctly enforcing embargo

Tests for making sure groups work correctly with embargo
