### PR TITLE
HYDRASRI-88 intercept 404 on thumbnail with default thumbnail

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -4,4 +4,32 @@ class DownloadsController < ApplicationController
   include Sufia::Noid # for normalize_identifier method
   include Hydra::Controller::DownloadBehavior
   prepend_before_filter :normalize_identifier, except: [:index, :new, :create]
+
+  def datastream_to_show
+    super
+  rescue Exception => e
+    if params[:datastream_id] == 'thumbnail'
+      respond_with_default_thumbnail_image
+      return false
+    else
+      raise e
+    end
+  end
+
+  protected
+
+  def render_404
+    if params[:datastream_id] == 'thumbnail'
+      respond_with_default_thumbnail_image
+    else
+      super
+    end
+  end
+
+  # Send default thumbnail image
+  def respond_with_default_thumbnail_image
+    image= ActionController::Base.helpers.asset_path("curate/default.png", type: :image)
+    redirect_to image
+  end
+
 end

--- a/app/views/catalog/_index_partials/_thumbnail_display.html.erb
+++ b/app/views/catalog/_index_partials/_thumbnail_display.html.erb
@@ -2,6 +2,8 @@
   <%= image_tag document.representative_image_url, class: "canonical-image"  %>
 <%- elsif document.respond_to?(:representative) && document.representative.present? %>
   <%= image_tag download_path(document.representative, {:datastream_id => 'thumbnail'}), class: "canonical-image"  %>
+<%- elsif document.persisted? -%>
+  <%= image_tag download_path(document, {:datastream_id => 'thumbnail'}), class: "canonical-image" %>
 <%- else -%>
-    <%= image_tag download_path(document, {:datastream_id => 'thumbnail'}), class: "canonical-image" %>
+  <span class="canonical-image"></span>
 <%- end -%>

--- a/app/views/catalog/_index_partials/_thumbnail_display.html.erb
+++ b/app/views/catalog/_index_partials/_thumbnail_display.html.erb
@@ -3,5 +3,5 @@
 <%- elsif document.respond_to?(:representative) && document.representative.present? %>
   <%= image_tag download_path(document.representative, {:datastream_id => 'thumbnail'}), class: "canonical-image"  %>
 <%- else -%>
-  <span class="canonical-image"></span>
+    <%= image_tag download_path(document, {:datastream_id => 'thumbnail'}), class: "canonical-image" %>
 <%- end -%>


### PR DESCRIPTION
intercept 404 on thumbnail with default thumbnail

Render default thumnail when thumbnail unavailable for any work

This commit with rescue 404 and 500 error with default thumbnail when trying to download thumbnail
