### PR TITLE
Adjusting Registration updates for managers

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,7 +9,7 @@ class RegistrationsController < Devise::RegistrationsController
     if current_user.manager?
       manager_is_updating_a_user_registration(&block)
     else
-      curruent_user_is_updating_their_user_registration(&block)
+      current_user_is_updating_their_user_registration(&block)
     end
   end
 
@@ -21,22 +21,25 @@ class RegistrationsController < Devise::RegistrationsController
       user = User.find(params[:user][:id])
       self.resource = resource_class.to_adapter.get!(user)
       scrub_password_parameters_for_manager!
-      handle_update_response(skip_signin: true, &block)
+      update_status = resource.update_without_password(account_update_params)
+      handle_update_response(update_status: update_status, skip_signin: true, &block)
     else
       curruent_user_is_updating_their_user_registration(&block)
     end
   end
 
-  def curruent_user_is_updating_their_user_registration(&block)
+  def current_user_is_updating_their_user_registration(&block)
     user = send(:"current_#{resource_name}").to_key
     self.resource = resource_class.to_adapter.get!(user)
-    handle_update_response(skip_signin: false, &block)
+    update_status = resource.update_with_password(account_update_params)
+    handle_update_response(successful_update: update_status, skip_signin: false, &block)
   end
 
   def handle_update_response(options = {}, &block)
     skip_signin = options.fetch(:skip_signin) { false }
-    if resource.update_without_password(account_update_params)
-      yield(resource) if block_given
+    successful_update = options.fetch(:successful_update)
+    if successful_update
+      yield(resource) if block_given?
       if is_navigational_format?
         flash_key =
         if update_needs_confirmation?(resource, prev_unconfirmed_email)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -32,12 +32,12 @@ class RegistrationsController < Devise::RegistrationsController
     user = send(:"current_#{resource_name}").to_key
     self.resource = resource_class.to_adapter.get!(user)
     update_status = resource.update_with_password(account_update_params)
-    handle_update_response(successful_update: update_status, skip_signin: false, &block)
+    handle_update_response(update_status: update_status, skip_signin: false, &block)
   end
 
   def handle_update_response(options = {}, &block)
     skip_signin = options.fetch(:skip_signin) { false }
-    successful_update = options.fetch(:successful_update)
+    successful_update = options.fetch(:update_status)
     if successful_update
       yield(resource) if block_given?
       if is_navigational_format?

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,32 +2,51 @@ class RegistrationsController < Devise::RegistrationsController
   include Curate::ThemedLayoutController
   with_themed_layout '1_column'
 
-  def update
+  # @TODO - Instead of updating user accounts via the registration controller,
+  #         expose a resource for updating an account. It is possible that the
+  #         resource would only be available for repository managers.
+  def update(&block)
     if current_user.manager?
-      self.resource = resource_class.to_adapter.get!(User.find(params[:user][:id]))
+      manager_is_updating_a_user_registration(&block)
     else
-      self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
+      curruent_user_is_updating_their_user_registration(&block)
     end
-    prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
+  end
 
-    if current_user.manager?
-      if account_update_params[:password].blank?
-        account_update_params.delete("password")
-        account_update_params.delete("password_confirmation")
-      end
-      successfully_updated = resource.update_without_password(account_update_params)
+  protected
+
+  def manager_is_updating_a_user_registration(&block)
+    manager_is_editing_another_user = params.fetch(:user, {}).fetch(:id, nil)
+    if manager_is_editing_another_user
+      user = User.find(params[:user][:id])
+      self.resource = resource_class.to_adapter.get!(user)
+      scrub_password_parameters_for_manager!
+      handle_update_response(skip_signin: true, &block)
     else
-      successfully_updated = update_resource(resource, account_update_params)
+      curruent_user_is_updating_their_user_registration(&block)
     end
+  end
 
-    if successfully_updated
-      yield resource if block_given?
-      if is_flashing_format?
-        flash_key = update_needs_confirmation?(resource, prev_unconfirmed_email) ?
-          :update_needs_confirmation : :updated
+  def curruent_user_is_updating_their_user_registration(&block)
+    user = send(:"current_#{resource_name}").to_key
+    self.resource = resource_class.to_adapter.get!(user)
+    handle_update_response(skip_signin: false, &block)
+  end
+
+  def handle_update_response(options = {}, &block)
+    skip_signin = options.fetch(:skip_signin) { false }
+    if resource.update_without_password(account_update_params)
+      yield(resource) if block_given
+      if is_navigational_format?
+        flash_key =
+        if update_needs_confirmation?(resource, prev_unconfirmed_email)
+          :update_needs_confirmation
+        else
+          :updated
+        end
         set_flash_message :notice, flash_key
       end
-      sign_in resource_name, resource, bypass: true unless current_user.manager?
+      sign_in resource_name, resource, bypass: true unless skip_signin
       respond_with resource, location: after_update_path_for(resource)
     else
       clean_up_passwords resource
@@ -35,11 +54,24 @@ class RegistrationsController < Devise::RegistrationsController
     end
   end
 
-  protected
-
   def after_update_path_for(resource)
     resource.update_column(:user_does_not_require_profile_update, true)
     super
+  end
+
+  def scrub_password_parameters_for_manager!
+    if account_update_params[:password].blank?
+      account_update_params.delete('password')
+      account_update_params.delete('password_confirmation')
+    end
+  end
+
+  def prev_unconfirmed_email
+    if resource.respond_to?(:unconfirmed_email)
+      resource.unconfirmed_email
+    else
+      nil
+    end
   end
 
   def resource_class

--- a/app/models/curate/user_behavior/base.rb
+++ b/app/models/curate/user_behavior/base.rb
@@ -30,7 +30,15 @@ module Curate
 
       def manager_usernames
         manager_config = 'config/manager_usernames.yml'
-        File.exist?(manager_config) ? @manager_usernames ||= YAML.load(ERB.new(Rails.root.join(manager_config).read).result)[Rails.env]['manager_usernames'] : @manager_usernames = ''
+        @manager_usernames ||= begin
+          if File.exist?(manager_config)
+            content = Rails.root.join(manager_config).read
+            YAML.load(ERB.new(content).result).fetch(Rails.env).
+              fetch('manager_usernames')
+          else
+            []
+          end
+        end
       end
 
       def name


### PR DESCRIPTION
In the case where a new user is attempting to sign up, and that user
is a repository manager, the Registration#update action was failing.
This is because `params[:user][:id]` was nil; The
RegistrationController is typically a singular resource (i.e. a
resource in which a given user has one and only one resource, and thus
there is no params[:id] that is passed).

So I am adding some descriptive methods to say what is happening. If
you are not a repository manager we update your account straight away.
If you are a repository manager, we determine if you are updating
another user's account or if you are updating your own account.

This is a stop gap measure as it is rearranging behavior that was
previously moved from Devise into Curate.

Also adjusting how the manager is looked up; By favoring Hash#fetch
over Hash#[], an exception is raised earlier rather than later.
