### PR TITLE
Remove associations when a Group/Work is deleted

### DIFF
--- a/app/repository_models/curation_concern/work.rb
+++ b/app/repository_models/curation_concern/work.rb
@@ -12,6 +12,10 @@ module CurationConcern
     end
     include Hydra::AccessControls::Permissions
 
+    included do
+      before_destroy :clear_associations
+    end
+
     def to_solr(solr_doc={}, opts={})
       super(solr_doc, opts)
       Solrizer.set_field(solr_doc, 'generic_type', 'Work', :facetable)
@@ -47,12 +51,35 @@ module CurationConcern
 
     def remove_editor(editor)
       if( ( self.depositor != editor.depositor ) && ( self.editors.include?( editor ) ) )
-        self.editors.delete(editor)
-        self.edit_users = self.edit_users - [editor.depositor]
-        self.save!
-        editor.works.delete(self)
-        editor.save!
+        remove_candidate_editor(editor)
       end
+    end
+
+    private
+
+    def clear_associations
+      clear_editor_groups
+      clear_editors
+    end
+
+    def clear_editor_groups
+      self.editor_groups.each do |editor_group|
+        remove_editor_group(editor_group)
+      end
+    end
+
+    def clear_editors
+      self.editors.each do |editor|
+        remove_candidate_editor(editor)
+      end
+    end
+
+    def remove_candidate_editor(editor)
+      self.editors.delete(editor)
+      self.edit_users = self.edit_users - [editor.depositor]
+      self.save!
+      editor.works.delete(self)
+      editor.save!
     end
   end
 end

--- a/app/views/hydramata/groups/index.html.erb
+++ b/app/views/hydramata/groups/index.html.erb
@@ -5,6 +5,7 @@
 </h2>
 <br/>
 <%- if has_any_group? %>
+  <%= render_pagination_info @response, :entry_name=>'item' %>
   <%= render_document_index %>
 <%- else %>
   <div class="span12 main-header">

--- a/lib/generators/curate/predicate_mapping/predicate_mappings.yml
+++ b/lib/generators/curate/predicate_mapping/predicate_mappings.yml
@@ -60,5 +60,5 @@
     :is_crop_of: isCropOf
     :is_editor_of: isEditorOf
     :has_editor: hasEditor
-    :is_editor_group_of: isiEditorGroupOf
+    :is_editor_group_of: isEditorGroupOf
     :has_editor_group: hasEditorGroup

--- a/spec/repository_models/generic_work_spec.rb
+++ b/spec/repository_models/generic_work_spec.rb
@@ -148,6 +148,29 @@ describe GenericWork do
         work.editor_groups.should == []
         work.edit_groups.should_not include(group.pid)
       end
+
+      let(:new_work) { FactoryGirl.create(:generic_work, user: person.user) }
+      it 'should delete relationship when related object is deleted' do
+        new_work.edit_groups.should == []
+        new_work.add_editor_group(group)
+
+        reload_new_work = GenericWork.find(new_work.pid)
+        new_work = reload_new_work
+
+        new_work.editor_groups.should == [group]
+        new_work.edit_groups.should include(group.pid)
+        new_work.datastreams['RELS-EXT'].content.to_s.should include(group.pid)
+
+        group_pid = group.pid
+        group.destroy
+
+        reload_new_work = GenericWork.find(new_work.pid)
+        new_work = reload_new_work
+
+        new_work.editor_groups.should == []
+        new_work.edit_groups.should_not include(group_pid)
+        new_work.datastreams['RELS-EXT'].content.to_s.should_not include(group_pid)
+      end
     end
   end
 end


### PR DESCRIPTION
When a group/work is destroyed, the relationship is not deleted in the RELS-EXT datastream. This commit fixes this bug.

This bug is not in jira.
