### PR TITLE
Fix group add/remove member inconsistencies.

### DIFF
--- a/app/controllers/hydramata/groups_controller.rb
+++ b/app/controllers/hydramata/groups_controller.rb
@@ -21,6 +21,7 @@ class Hydramata::GroupsController < ApplicationController
   self.copy_blacklight_config_from(CatalogController)
 
   def index
+    params[:per_page] ||= 50
     super
   end
 

--- a/app/repository_models/hydramata/group_membership_form.rb
+++ b/app/repository_models/hydramata/group_membership_form.rb
@@ -12,6 +12,8 @@ class Hydramata::GroupMembershipForm
   attribute :no_editors, Boolean
 
   delegate :add_member, to: :group
+  delegate :group_read_membership, to: :group
+  delegate :group_edit_membership, to: :group
 
   def group
     if self.group_id
@@ -32,7 +34,7 @@ class Hydramata::GroupMembershipForm
   end
 
   def save
-    if no_editors
+    if no_editors || !atleast_one_manager_present?
       errors.add(:no_editors, "The Group needs atleast one editor")
       false
     else
@@ -49,22 +51,38 @@ class Hydramata::GroupMembershipForm
     @group.add_member(self.current_user.person, 'editor')
   end
 
+  def atleast_one_manager_present?
+    managers.select{|manager| manager if manager[:action] != "destroy"}.size >= 1
+  end
+
+  def managers
+    members.select{|mem| mem if mem[:role] == "manager" }
+  end
+
+  #TODO
+  # The Group object is maintaining stale value for some reason.
+  # The object has to be reloaded everytime to get the consistent result.
+  # I dont like this either. Hope this will get refactored when curate goes through refactoring.
+  # Scenario where I found this: 
+  # When a member is removed from the group and immediately added back in the same update, then
+  # the member is removed but not added back (even though it was added back).
   def persist
-    self.group.title = self.title
-    self.group.description = self.description
+    group.title = self.title
+    group.description = self.description
+    group.save
     self.members.each do |member|
+      group.reload
       if member[:action] == 'create'
-        self.group.add_member( person( member[:person_id] ), member[:role] )
+        add_member( person( member[:person_id] ), member[:role] )
       elsif member[:action] == 'destroy'
-        self.group.remove_member( person( member[:person_id] ) )
+        group.remove_member( person( member[:person_id] ) )
       elsif member[:action] == 'none'
         if member[:role] == 'manager'
-          self.group.group_edit_membership( person( member[:person_id] ) )
+          group_edit_membership( person( member[:person_id] ) )
         elsif !member[:person_id].blank?
-          self.group.group_read_membership( person( member[:person_id] ) )
+          group_read_membership( person( member[:person_id] ) )
         end
       end
     end
-    self.group.save
   end
 end

--- a/app/services/hydramata/group_membership_action_parser.rb
+++ b/app/services/hydramata/group_membership_action_parser.rb
@@ -55,7 +55,7 @@ module Hydramata::GroupMembershipActionParser
     end
     action.each_with_index do |member_action, index|
       person_id = params["hydramata_group"]["members_attributes"][index.to_s]["id"]
-      if person_id
+      if person_id.present?
         role = params["group_member"]["edit_users_ids"].include?(person_id) ? "manager" : "member"
         new_params_hash = Hash[person_id: person_id, action: member_action, role: role]
         new_params_aggregate << new_params_hash

--- a/app/views/hydramata/groups/_linked_members.html.erb
+++ b/app/views/hydramata/groups/_linked_members.html.erb
@@ -81,7 +81,7 @@
               <label class="checkbox inline-checkbox">
                 <% if ( @group.edit_users.include?(memberField.object.depositor) && ( @group.edit_users.size == 1 ) ) %>
                   <%= check_box_tag "current_user_disabled", 'checked', true, disabled: true %>
-                  <%= hidden_field_tag "group_member[edit_users_ids][]", @group.edit_users.include?(memberField.object.depositor) %>
+                  <%= hidden_field_tag "group_member[edit_users_ids][]", memberField.object.pid %>
                 <% else %>
                   <%= check_box_tag "group_member[edit_users_ids][]", memberField.object.id, @group.edit_users.include?(memberField.object.depositor) %>
                 <% end %>

--- a/spec/repository_models/hydramata/group_membership_form_spec.rb
+++ b/spec/repository_models/hydramata/group_membership_form_spec.rb
@@ -25,6 +25,10 @@ describe Hydramata::GroupMembershipForm do
     { group_id: group.pid, title: "Title 2", description: "Description for Title 2", members: members_with_no_editors, no_editors: true }
   }
 
+  let(:params_5) {
+    { group_id: group.pid, title: "Title 1", description: "Description for Title 1", members: remove_member_and_add_them_back }
+  }
+
   let(:members_to_add) {
     [
       { person_id: person_1.pid, action: "create", role: "manager" },
@@ -34,6 +38,7 @@ describe Hydramata::GroupMembershipForm do
 
   let(:members_to_remove) {
     [
+      { person_id: person_1.pid, action: "none", role: "manager" },
       { person_id: person_2.pid, action: "destroy", role: "member" }
     ]
   }
@@ -48,6 +53,14 @@ describe Hydramata::GroupMembershipForm do
     [
       { person_id: person_1.pid, action: "create", role: "member" },
       { person_id: person_2.pid, action: "none", role: "member" }
+    ]
+  }
+
+  let(:remove_member_and_add_them_back) {
+    [
+      { person_id: person_2.pid, action: "destroy", role: "member" },
+      { person_id: person_1.pid, action: "none", role: "manager" },
+      { person_id: person_2.pid, action: "create", role: "member" }
     ]
   }
   context '#save' do
@@ -95,6 +108,20 @@ describe Hydramata::GroupMembershipForm do
     it 'should have atleast one editor' do
       @gmf = Hydramata::GroupMembershipForm.new(params_4)
       @gmf.save.should == false 
+    end
+
+    it 'should add back member which was deleted in the same update' do
+      @gmf.save
+      group = Hydramata::Group.find(@gmf.group.pid)
+      group.members.should == [person_1, person_2]
+
+      @gmf_update = Hydramata::GroupMembershipForm.new(params_5)
+      @gmf_update.save
+
+      group = Hydramata::Group.find(@gmf_update.group.pid)
+
+      group.members.should == [person_1, person_2]
+      @gmf.group.pid.should == @gmf_update.group.pid
     end
   end
 


### PR DESCRIPTION
This fixes some of the inconsistencies with groups.
1. should display error message if all the members in the group are deleted rather than silently failing.
2. resolve the issue when a member is deleted and added back in one update action.
3. increase the max limit for number of groups displayes to 50 (until we have pagination for this)

There is no story/ticket for this in jira.
