### PR TITLE
Adding StyleGuide enforcement for Hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,782 @@
+################################################################################
+##
+## Custom options for Curate
+## These options were plucked from below and modified accordingly.
+##
+################################################################################
+MethodLength:
+  Max: 10
+  Description: 'Avoid methods longer than 10 lines of code.'
+  CountComments: false
+  Enabled: true
+
+LineLength:
+  Description: 'Limit lines to 140 characters.'
+  Max: 140
+  Enabled: true
+
+ClassLength:
+  Max: 100
+  Description: 'Avoid classes longer than 100 lines of code.'
+  CountComments: false
+  Enabled: true
+
+################################################################################
+##
+## Below this banner, the configuration options were copied from the following
+## URL:
+## https://raw.githubusercontent.com/bbatsov/rubocop/master/config/enabled.yml
+##
+################################################################################
+
+# These are all the cops that are enabled in the default configuration.
+
+AccessModifierIndentation:
+  Description: Check indentation of private/protected visibility modifiers.
+  Enabled: true
+
+AccessorMethodName:
+  Description: Check the naming of accessor methods for get_/set_.
+  Enabled: true
+
+Alias:
+  Description: 'Use alias_method instead of alias.'
+  Enabled: true
+
+AlignArray:
+  Description: >-
+                 Align the elements of an array literal if they span more than
+                 one line.
+  Enabled: true
+
+AlignHash:
+  Description: >-
+                 Align the elements of a hash literal if they span more than
+                 one line.
+  Enabled: true
+
+AlignParameters:
+  Description: >-
+                 Align the parameters of a method call if they span more
+                 than one line.
+  Enabled: true
+
+AndOr:
+  Description: 'Use &&/|| instead of and/or.'
+  Enabled: true
+
+ArrayJoin:
+  Description: 'Use Array#join instead of Array#*.'
+  Enabled: true
+
+AsciiComments:
+  Description: 'Use only ascii symbols in comments.'
+  Enabled: true
+
+AsciiIdentifiers:
+  Description: 'Use only ascii symbols in identifiers.'
+  Enabled: true
+
+Attr:
+  Description: 'Checks for uses of Module#attr.'
+  Enabled: true
+
+BeginBlock:
+  Description: 'Avoid the use of BEGIN blocks.'
+  Enabled: true
+
+BlockComments:
+  Description: 'Do not use block comments.'
+  Enabled: true
+
+BlockNesting:
+  Description: 'Avoid excessive block nesting'
+  Enabled: true
+
+Blocks:
+  Description: >-
+                Avoid using {...} for multi-line blocks (multiline chaining is
+                always ugly).
+                Prefer {...} over do...end for single-line blocks.
+  Enabled: true
+
+BracesAroundHashParameters:
+  Description: 'Enforce braces style inside hash parameters.'
+  Enabled: true
+
+CaseEquality:
+  Description: 'Avoid explicit use of the case equality operator(===).'
+  Enabled: true
+
+CaseIndentation:
+  Description: 'Indentation of when in a case/when/[else/]end.'
+  Enabled: true
+
+CharacterLiteral:
+  Description: 'Checks for uses of character literals.'
+  Enabled: true
+
+ClassAndModuleCamelCase:
+  Description: 'Use CamelCase for classes and modules.'
+  Enabled: true
+
+ClassAndModuleChildren:
+  Description: 'Checks style of children classes and modules.'
+  Enabled: true
+
+ClassMethods:
+  Description: 'Use self when defining module/class methods.'
+  Enabled: true
+
+ClassVars:
+  Description: 'Avoid the use of class variables.'
+  Enabled: true
+
+CollectionMethods:
+  Description: 'Preferred collection methods.'
+  Enabled: true
+
+ColonMethodCall:
+  Description: 'Do not use :: for method call.'
+  Enabled: true
+
+CommentAnnotation:
+  Description: >-
+                 Checks formatting of special comments
+                 (TODO, FIXME, OPTIMIZE, HACK, REVIEW).
+  Enabled: true
+
+CommentIndentation:
+  Description: 'Indentation of comments.'
+  Enabled: true
+
+ConstantName:
+  Description: 'Constants should use SCREAMING_SNAKE_CASE.'
+  Enabled: true
+
+CyclomaticComplexity:
+  Description: 'Avoid complex methods.'
+  Enabled: true
+
+DefWithParentheses:
+  Description: 'Use def with parentheses when there are arguments.'
+  Enabled: true
+
+Delegate:
+  Description: 'Prefer delegate method for delegations.'
+  Enabled: true
+
+DeprecatedHashMethods:
+  Description: 'Checks for use of deprecated Hash methods.'
+  Enabled: true
+
+Documentation:
+  Description: 'Document classes and non-namespace modules.'
+  Enabled: true
+
+DotPosition:
+  Description: 'Checks the position of the dot in multi-line method calls.'
+  Enabled: true
+
+DoubleNegation:
+  Description: 'Checks for uses of double negation (!!).'
+  Enabled: true
+
+EachWithObject:
+  Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
+  Enabled: true
+
+EmptyLineBetweenDefs:
+  Description: 'Use empty lines between defs.'
+  Enabled: true
+
+EmptyLines:
+  Description: "Don't use several empty lines in a row."
+  Enabled: true
+
+EmptyLinesAroundAccessModifier:
+  Description: "Keep blank lines around access modifiers."
+  Enabled: true
+
+EmptyLinesAroundBody:
+  Description: "Keeps track of empty lines around expression bodies."
+  Enabled: true
+
+EmptyLiteral:
+  Description: 'Prefer literals to Array.new/Hash.new/String.new.'
+  Enabled: true
+
+Encoding:
+  Description: 'Use UTF-8 as the source file encoding.'
+  Enabled: true
+
+EndBlock:
+  Description: 'Avoid the use of END blocks.'
+  Enabled: true
+
+EndOfLine:
+  Description: 'Use Unix-style line endings.'
+  Enabled: true
+
+EvenOdd:
+  Description: 'Favor the use of Fixnum#even? && Fixnum#odd?'
+  Enabled: true
+
+FileName:
+  Description: 'Use snake_case for source file names.'
+  Enabled: true
+
+FlipFlop:
+  Description: 'Checks for flip flops'
+  Enabled: true
+
+For:
+  Description: 'Checks use of for or each in multiline loops.'
+  Enabled: true
+
+FormatString:
+  Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
+  Enabled: true
+
+GlobalVars:
+  Description: 'Do not introduce global variables.'
+  Enabled: true
+
+HashSyntax:
+  Description: >-
+                 Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax
+                 { :a => 1, :b => 2 }.
+  Enabled: true
+
+IfUnlessModifier:
+  Description: >-
+                 Favor modifier if/unless usage when you have a
+                 single-line body.
+  Enabled: true
+
+IfWithSemicolon:
+  Description: 'Never use if x; .... Use the ternary operator instead.'
+  Enabled: true
+
+IndentationConsistency:
+  Description: 'Keep indentation straight.'
+  Enabled: true
+
+IndentationWidth:
+  Description: 'Use 2 spaces for indentation.'
+  Enabled: true
+
+IndentArray:
+  Description: >-
+                 Checks the indentation of the first element in an array
+                 literal.
+  Enabled: true
+
+IndentHash:
+  Description: 'Checks the indentation of the first key in a hash literal.'
+  Enabled: true
+
+Lambda:
+  Description: 'Use the new lambda literal syntax for single-line blocks.'
+  Enabled: true
+
+LambdaCall:
+  Description: 'Use lambda.call(...) instead of lambda.(...).'
+  Enabled: true
+
+LeadingCommentSpace:
+  Description: 'Comments should start with a space.'
+  Enabled: true
+
+LineEndConcatenation:
+  Description: >-
+                 Use \ instead of + or << to concatenate two string literals at
+                 line end.
+  Enabled: true
+
+MethodCallParentheses:
+  Description: 'Do not use parentheses for method calls with no arguments.'
+  Enabled: true
+
+MethodDefParentheses:
+  Description: >-
+                 Checks if the method definitions have or don't have
+                 parentheses.
+  Enabled: true
+
+MethodName:
+  Description: 'Use the configured style when naming methods.'
+  Enabled: true
+
+ModuleFunction:
+  Description: 'Checks for usage of `extend self` in modules.'
+  Enabled: true
+
+MultilineBlockChain:
+  Description: 'Avoid multi-line chains of blocks.'
+  Enabled: true
+
+MultilineIfThen:
+  Description: 'Never use then for multi-line if/unless.'
+  Enabled: true
+
+MultilineTernaryOperator:
+  Description: >-
+                 Avoid multi-line ?: (the ternary operator);
+                 use if/unless instead.
+  Enabled: true
+
+NegatedIf:
+  Description: >-
+                 Favor unless over if for negative conditions
+                 (or control flow or).
+  Enabled: true
+
+NegatedWhile:
+  Description: 'Favor until over while for negative conditions.'
+  Enabled: true
+
+NestedTernaryOperator:
+  Description: 'Use one expression per branch in a ternary operator.'
+  Enabled: true
+
+Next:
+  Description: 'Use `next` to skip iteration instead of a condition at the end.'
+  Enabled: true
+
+NilComparison:
+  Description: 'Prefer x.nil? to x == nil.'
+  Enabled: true
+
+NonNilCheck:
+  Description: 'Checks for redundant nil checks.'
+  Enabled: true
+
+Not:
+  Description: 'Use ! instead of not.'
+  Enabled: true
+
+NumericLiterals:
+  Description: >-
+                 Add underscores to large numeric literals to improve their
+                 readability.
+  Enabled: true
+
+OneLineConditional:
+  Description: >-
+                 Favor the ternary operator(?:) over
+                 if/then/else/end constructs.
+  Enabled: true
+
+OpMethod:
+  Description: 'When defining binary operators, name the argument other.'
+  Enabled: true
+
+ParameterLists:
+  Description: 'Avoid parameter lists longer than three or four parameters.'
+  Enabled: true
+
+ParenthesesAroundCondition:
+  Description: >-
+                 Don't use parentheses around the condition of an
+                 if/unless/while.
+  Enabled: true
+
+PercentLiteralDelimiters:
+  Description: 'Use `%`-literal delimiters consistently'
+  Enabled: true
+
+PerlBackrefs:
+  Description: 'Avoid Perl-style regex back references.'
+  Enabled: true
+
+PredicateName:
+  Description: 'Check the names of predicate methods.'
+  Enabled: true
+
+Proc:
+  Description: 'Use proc instead of Proc.new.'
+  Enabled: true
+
+RaiseArgs:
+  Description: 'Checks the arguments passed to raise/fail.'
+  Enabled: true
+
+RedundantBegin:
+  Description: "Don't use begin blocks when they are not needed."
+  Enabled: true
+
+RedundantException:
+  Description: "Checks for an obsolete RuntimeException argument in raise/fail."
+  Enabled: true
+
+RedundantReturn:
+  Description: "Don't use return where it's not required."
+  Enabled: true
+
+RedundantSelf:
+  Description: "Don't use self where it's not needed."
+  Enabled: true
+
+RegexpLiteral:
+  Description: >-
+                 Use %r for regular expressions matching more than
+                 `MaxSlashes` '/' characters.
+                 Use %r only for regular expressions matching more than
+                 `MaxSlashes` '/' character.
+  Enabled: true
+
+RescueModifier:
+  Description: 'Avoid using rescue in its modifier form.'
+  Enabled: true
+
+SelfAssignment:
+  Description: 'Checks for places where self-assignment shorthand should have been used.'
+  Enabled: true
+
+Semicolon:
+  Description: "Don't use semicolons to terminate expressions."
+  Enabled: true
+
+SignalException:
+  Description: 'Checks for proper usage of fail and raise.'
+  Enabled: true
+
+SingleLineBlockParams:
+  Description: 'Enforces the names of some block params.'
+  Enabled: true
+
+SingleLineMethods:
+  Description: 'Avoid single-line methods.'
+  Enabled: true
+
+SingleSpaceBeforeFirstArg:
+  Description: >-
+                 Checks that exactly one space is used between a method name
+                 and the first argument for method calls without parentheses.
+  Enabled: true
+
+SpaceAfterColon:
+  Description: 'Use spaces after colons.'
+  Enabled: true
+
+SpaceAfterComma:
+  Description: 'Use spaces after commas.'
+  Enabled: true
+
+SpaceAfterControlKeyword:
+  Description: 'Use spaces after if/elsif/unless/while/until/case/when.'
+  Enabled: true
+
+SpaceAfterMethodName:
+  Description: >-
+                 Never put a space between a method name and the opening
+                 parenthesis in a method definition.
+  Enabled: true
+
+SpaceAfterNot:
+  Description: Tracks redundant space after the ! operator.
+  Enabled: true
+
+SpaceAfterSemicolon:
+  Description: 'Use spaces after semicolons.'
+  Enabled: true
+
+SpaceBeforeBlockBraces:
+  Description: >-
+                 Checks that the left block brace has or doesn't have space
+                 before it.
+  Enabled: true
+
+SpaceInsideBlockBraces:
+  Description: >-
+                 Checks that block braces have or don't have surrounding space.
+                 For blocks taking parameters, checks that the left brace has
+                 or doesn't have trailing space.
+  Enabled: true
+
+SpaceAroundEqualsInParameterDefault:
+  Description: >-
+                 Checks that the equals signs in parameter default assignments
+                 have or don't have surrounding space depending on
+                 configuration.
+  Enabled: true
+
+SpaceAroundOperators:
+  Description: 'Use spaces around operators.'
+  Enabled: true
+
+SpaceBeforeModifierKeyword:
+  Description: 'Put a space before the modifier keyword.'
+  Enabled: true
+
+SpaceInsideBrackets:
+  Description: 'No spaces after [ or before ].'
+  Enabled: true
+
+SpaceInsideHashLiteralBraces:
+  Description: "Use spaces inside hash literal braces - or don't."
+  Enabled: true
+
+SpaceInsideParens:
+  Description: 'No spaces after ( or before ).'
+  Enabled: true
+
+SpecialGlobalVars:
+  Description: 'Avoid Perl-style global variables.'
+  Enabled: true
+
+StringLiterals:
+  Description: 'Checks if uses of quotes match the configured preference.'
+  Enabled: true
+
+Tab:
+  Description: 'No hard tabs.'
+  Enabled: true
+
+TrailingBlankLines:
+  Description: 'Checks trailing blank lines and final newline.'
+  Enabled: true
+
+TrailingComma:
+  Description: 'Checks for trailing comma in parameter lists and literals.'
+  Enabled: true
+
+TrailingWhitespace:
+  Description: 'Avoid trailing whitespace.'
+  Enabled: true
+
+TrivialAccessors:
+  Description: 'Prefer attr_* methods to trivial readers/writers.'
+  Enabled: true
+
+UnlessElse:
+  Description: >-
+                 Never use unless with else. Rewrite these with the positive
+                 case first.
+  Enabled: true
+
+UnneededCapitalW:
+  Description: 'Checks for %W when interpolation is not needed.'
+  Enabled: true
+
+VariableInterpolation:
+  Description: >-
+                 Don't interpolate global, instance and class variables
+                 directly in strings.
+  Enabled: true
+
+VariableName:
+  Description: 'Use the configured style when naming variables.'
+  Enabled: true
+
+WhenThen:
+  Description: 'Use when x then ... for one-line cases.'
+  Enabled: true
+
+WhileUntilDo:
+  Description: 'Checks for redundant do after while or until.'
+  Enabled: true
+
+WhileUntilModifier:
+  Description: >-
+                 Favor modifier while/until usage when you have a
+                 single-line body.
+  Enabled: true
+
+WordArray:
+  Description: 'Use %w or %W for arrays of words.'
+  Enabled: true
+
+#################### Lint ################################
+### Warnings
+
+AmbiguousOperator:
+  Description: >-
+                 Checks for ambiguous operators in the first argument of a
+                 method invocation without parentheses.
+  Enabled: true
+
+AmbiguousRegexpLiteral:
+  Description: >-
+                 Checks for ambiguous regexp literals in the first argument of
+                 a method invocation without parenthesis.
+  Enabled: true
+
+AssignmentInCondition:
+  Description: "Don't use assignment in conditions."
+  Enabled: true
+
+BlockAlignment:
+  Description: 'Align block ends correctly.'
+  Enabled: true
+
+ConditionPosition:
+  Description: 'Checks for condition placed in a confusing position relative to the keyword.'
+  Enabled: true
+
+Debugger:
+  Description: 'Check for debugger calls.'
+  Enabled: true
+
+DeprecatedClassMethods:
+  Description: 'Check for deprecated class method calls.'
+  Enabled: true
+
+ElseLayout:
+  Description: 'Check for odd code arrangement in an else block.'
+  Enabled: true
+
+EmptyEnsure:
+  Description: 'Checks for empty ensure block.'
+  Enabled: true
+
+EmptyInterpolation:
+  Description: 'Checks for empty string interpolation.'
+  Enabled: true
+
+EndAlignment:
+  Description: 'Align ends correctly.'
+  Enabled: true
+
+EndInMethod:
+  Description: 'END blocks should not be placed inside method definitions.'
+  Enabled: true
+
+EnsureReturn:
+  Description: 'Never use return in an ensure block.'
+  Enabled: true
+
+Eval:
+  Description: 'The use of eval represents a serious security risk.'
+  Enabled: true
+
+GuardClause:
+  Description: 'Check for conditionals that can be replaced with guard clauses'
+  Enabled: true
+
+HandleExceptions:
+  Description: "Don't suppress exception."
+  Enabled: true
+
+InvalidCharacterLiteral:
+  Description: >-
+                 Checks for invalid character literals with a non-escaped
+                 whitespace character.
+  Enabled: true
+
+LiteralInCondition:
+  Description: 'Checks of literals used in conditions.'
+  Enabled: true
+
+LiteralInInterpolation:
+  Description: 'Checks for literals used in interpolation.'
+  Enabled: true
+
+Loop:
+  Description: >-
+                 Use Kernel#loop with break rather than begin/end/until or
+                 begin/end/while for post-loop tests.
+  Enabled: true
+
+ParenthesesAsGroupedExpression:
+  Description: >-
+                 Checks for method calls with a space before the opening
+                 parenthesis.
+  Enabled: true
+
+RequireParentheses:
+  Description: >-
+                 Use parentheses in the method call to avoid confusion
+                 about precedence.
+  Enabled: true
+
+RescueException:
+  Description: 'Avoid rescuing the Exception class.'
+  Enabled: true
+
+ShadowingOuterLocalVariable:
+  Description: >-
+                 Do not use the same name as outer local variable
+                 for block arguments or block local variables.
+  Enabled: true
+
+SpaceBeforeFirstArg:
+  Description: >-
+                 Put a space between a method name and the first argument
+                 in a method call without parentheses.
+  Enabled: true
+
+StringConversionInInterpolation:
+  Description: 'Checks for Object#to_s usage in string interpolation.'
+  Enabled: true
+
+UnderscorePrefixedVariableName:
+  Description: 'Do not use prefix `_` for a variable that is used.'
+  Enabled: true
+
+UnusedBlockArgument:
+  Description: 'Checks for unused block arguments.'
+  Enabled: true
+
+UnusedMethodArgument:
+  Description: 'Checks for unused method arguments.'
+  Enabled: true
+
+UnreachableCode:
+  Description: 'Unreachable code.'
+  Enabled: true
+
+UselessAccessModifier:
+  Description: 'Checks for useless access modifiers.'
+  Enabled: true
+
+UselessAssignment:
+  Description: 'Checks for useless assignment to a local variable.'
+  Enabled: true
+
+UselessComparison:
+  Description: 'Checks for comparison of something with itself.'
+  Enabled: true
+
+UselessElseWithoutRescue:
+  Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
+  Enabled: true
+
+UselessSetterCall:
+  Description: 'Checks for useless setter call to a local variable.'
+  Enabled: true
+
+Void:
+  Description: 'Possible use of operator/literal/variable in void context.'
+  Enabled: true
+
+##################### Rails ##################################
+
+ActionFilter:
+  Description: 'Enforces consistent use of action filter methods.'
+  Enabled: true
+
+DefaultScope:
+  Description: 'Checks if the argument passed to default_scope is a block.'
+  Enabled: true
+
+HasAndBelongsToMany:
+  Description: 'Prefer has_many :through to has_and_belongs_to_many.'
+  Enabled: true
+
+Output:
+  Description: 'Checks for calls to puts, print, etc.'
+  Enabled: true
+
+ReadWriteAttribute:
+  Description: 'Checks for read_attribute(:attr) and write_attribute(:attr, val).'
+  Enabled: true
+
+ScopeArgs:
+  Description: 'Checks the arguments of ActiveRecord scopes.'
+  Enabled: true
+
+Validation:
+  Description: 'Use sexy validations.'
+  Enabled: true

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,15 @@
 ################################################################################
+## Releasing the hounds in your local environment.
+##
+## Setup:
+## $ gem install rubocop
+##
+## Run:
+## $ rubocop ./path/to/file ./or/path/to/directory -c ./.hound.yml
+##
+################################################################################
+
+################################################################################
 ##
 ## Custom options for Curate
 ## These options were plucked from below and modified accordingly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,13 +127,23 @@ If the contributor works for an institution, the institution must have a Corpora
 
 ## Coding Guidelines
 
-The [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide) is an excellent resource for how to craft your Ruby code, in particular the [Naming section](https://github.com/bbatsov/ruby-style-guide#naming).
+This project is using [HoundCI](https://houndci.com) to help support our agreed upon style guide.
+The style guide is a work in progress, and is declared in the project's `./hound.yml` file.
 
-Your code changes should include support tests.
+Hound is a Github integration tool that essentially runs [rubocop](http://rubygems.org/gems/rubocop).
 
+> Automatic Ruby code style checking tool. Aims to enforce the community-driven Ruby Style Guide.
+
+If you want to run `rubocop` with our style guide, first `gem install rubocop` then inside the project:
+
+```bash
+$ rubocop ./path/to/file ./or/path/to/directory -c ./.hound.yml
+```
 **Can I break these guidelines?** Yes. But you may need to convince the person merging your changes.
 
 ### Writing Your Specs
+
+Your code changes should include support tests.
 
 Before you begin writing code, think about the test that will verify the code you plan to write.
 A [well written story with Gherkin syntax](http://pivotallabs.com/well-formed-stories/) can help formulate the pre-conditions (Given), invocation (When), and post-conditions (Then).
@@ -285,8 +295,8 @@ When you do assign someone to the Pull Request, please make sure to add a commen
 
 As a reviewer, it is important that the pull request:
 
-* Has a (well written commit message)[#well-written-commit-messages]
-* Has (well written code)[#coding-guidelines]
+* Has a [well written commit message](#well-written-commit-messages)
+* Has [well written code](#coding-guidelines)
 * The test suite successfully builds
 * Any questions regarding the pull request are answered
 * Adjucate if the Pull Request should be squashed into a smaller number of commits


### PR DESCRIPTION
Per a developer conversation, we are going to expand our character
line length guide from 80 characters to 140 characters.

Fundamentally, we are asking that Rubocop run against the files you
are changing:

```
$ rubocop ./path/to/file_1 ./another/path -c ./.hound.yml
```

Hound enforces that on your pull request.
