### PR TITLE
FIX - Adding Group to GenericWork

### DIFF
--- a/app/repository_models/curation_concern/work_permission.rb
+++ b/app/repository_models/curation_concern/work_permission.rb
@@ -23,7 +23,7 @@ class CurationConcern::WorkPermission
         if attributes['id'].present?
           if has_destroy_flag?(attributes)
             sorted[:remove] << attributes['id']
-          elsif action_type == :create
+          elsif action_type == :create || action_type == :update
             sorted[:create] << attributes['id']
           end
         end

--- a/app/views/curation_concern/base/_linked_groups.html.erb
+++ b/app/views/curation_concern/base/_linked_groups.html.erb
@@ -9,7 +9,7 @@
       </label>
     </span>
     <div class="controls">
-      <% prefix = f.object.class.to_s.downcase %>
+      <% prefix = ActiveModel::Naming.singular_route_key(f.object.class) %>
 
       <script id="entry-template" type="text/x-handlebars-template">
         <li class="field-wrapper input-append">


### PR DESCRIPTION
HYDRASIR - 510 #close

I didn't write an automated test for this. But here are the steps that I followed to test:
1. login
2. click on '+' and select 'More Options'
3. click on 'Add New' for Generic Work
4. I entered title with "Title 1"
5. started typing in the Groups field and selected a group ("Group - 1") from the autocomplete
6. check the contributor license agreement
7. click on 'Create Generic work'

This created the GenericWork and navigated to its show view. From there:
8. click on 'Edit this Generic Work'

'Group - 1' link was listed in the Groups field.
