### PR TITLE
FIX - Adding Group to GenericWork

### DIFF
--- a/app/repository_models/curation_concern/work_permission.rb
+++ b/app/repository_models/curation_concern/work_permission.rb
@@ -23,7 +23,7 @@ class CurationConcern::WorkPermission
         if attributes['id'].present?
           if has_destroy_flag?(attributes)
             sorted[:remove] << attributes['id']
-          elsif action_type == :create
+          elsif action_type == :create || action_type == :update
             sorted[:create] << attributes['id']
           end
         end

--- a/app/views/curation_concern/base/_linked_groups.html.erb
+++ b/app/views/curation_concern/base/_linked_groups.html.erb
@@ -9,7 +9,7 @@
       </label>
     </span>
     <div class="controls">
-      <% prefix = f.object.class.to_s.downcase %>
+      <% prefix = ActiveModel::Naming.singular_route_key(f.object.class) %>
 
       <script id="entry-template" type="text/x-handlebars-template">
         <li class="field-wrapper input-append">

--- a/spec/features/select_representative_spec.rb
+++ b/spec/features/select_representative_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe "select representative file for work" do
-  let!(:user) { FactoryGirl.create(:user) }
+  let!(:person) { FactoryGirl.create(:person_with_user) }
+  let(:user) { person.user }
   let!(:file1){ FactoryGirl.create(:generic_file, title: ["Sample file 1"] ) }
   let!(:file2){ FactoryGirl.create(:generic_file, title: ["Sample file 2"] ) }
   let!(:work1) { FactoryGirl.create(:generic_work, user: user, title: 'Work 1' ) }


### PR DESCRIPTION
HYDRASIR - 510 #close

I didn't write an automated test for this. But I followed these steps for testing:
1. login 
2. click on '+' and select 'More Options' 
3. click on 'Add New' for Generic Work 
4. I entered title "Title 1" 
5. started typing in the Groups field and selected the Group "Group - 1" from the autocomplete 
6. check the contributor license agreement 
7. click on 'Create Generic work' 

This navigated to the GenericWork show view. From there: 
8. click on 'Edit this Generic Work' 

'Group - 1' link was listed in the Groups field. 
