### PR TITLE
Adding multi-value presence validation

### DIFF
--- a/app/repository_models/article.rb
+++ b/app/repository_models/article.rb
@@ -29,7 +29,7 @@ class Article < ActiveFedora::Base
     datastream: :descMetadata, multiple: true,
     label: "Contributing Author(s)",
     hint: "Who else played a non-primary role in the creation of your Article.",
-    validates: { presence: { message: "Your #{human_readable_type.downcase} must have #{label_with_indefinite_article}." }}
+    validates: { multi_value_presence: { message: "Your #{human_readable_type.downcase} must have #{label_with_indefinite_article}." }}
   attribute :repository_name,
     datastream: :descMetadata, multiple: false,
     label: "Repository Name",

--- a/app/repository_models/curation_concern/remotely_identified_by_doi.rb
+++ b/app/repository_models/curation_concern/remotely_identified_by_doi.rb
@@ -19,10 +19,7 @@ module CurationConcern
         attribute :existing_identifier,
           multiple: false, editable: true, displayable: false
 
-        # Given that a publisher could be an array or a single entity
-        # Then we need to account for both
-        # Conveniently [].length == 0 and "".length == 0
-        validates :publisher, length: { minimum: 1, message: 'is required for remote DOI minting', if: :remote_doi_assignment_strategy? }
+        validates :publisher, multi_value_presence: { message: 'is required for remote DOI minting', if: :remote_doi_assignment_strategy? }
 
         attr_writer :doi_remote_service
 

--- a/app/repository_models/dataset.rb
+++ b/app/repository_models/dataset.rb
@@ -26,7 +26,7 @@ class Dataset < ActiveFedora::Base
             validates: {presence: { message: 'You must select a license for your dataset.' }}
   attribute :contributor, datastream: :descMetadata,
             multiple: true,
-            validates: {presence: { message: "Your dataset must have a contributor."} }
+            validates: {multi_value_presence: { message: "Your dataset must have a contributor."} }
 
   attribute :created,                datastream: :descMetadata, multiple: false
   attribute :description,            datastream: :descMetadata, multiple: false

--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -32,7 +32,7 @@ class Etd < ActiveFedora::Base
       multiple: true,
       label: "Contributor(s)",
       hint: "Who else played a non-primary role in the creation of your #{etd_label}.",
-      validates: { presence: { message: "Your #{human_readable_type.downcase} must have #{label_with_indefinite_article}." } }
+      validates: { multi_value_presence: { message: "Your #{human_readable_type.downcase} must have #{label_with_indefinite_article}." } }
     ds.attribute :contributor_role,
       multiple: true,
       label: "Contributor role(s)",

--- a/app/repository_models/image.rb
+++ b/app/repository_models/image.rb
@@ -28,7 +28,7 @@ class Image < ActiveFedora::Base
       label: "Creator",
       hint: " Primary creator/s of the item.",
       multiple: true,
-      validates: { presence: { message: "Your #{image_label} must have a creator." } }
+      validates: { multi_value_presence: { message: "Your #{image_label} must have a creator." } }
 
     ds.attribute :date_created,
       default: Date.today.to_s("%Y-%m-%d"),

--- a/app/validators/multi_value_presence_validator.rb
+++ b/app/validators/multi_value_presence_validator.rb
@@ -1,0 +1,8 @@
+class MultiValuePresenceValidator < ActiveModel::EachValidator
+
+  def validate_each(record, attribute, input)
+    values = Array.wrap(input)
+    record.errors.add(attribute, :blank, options) unless values.any?(&:present?)
+  end
+
+end

--- a/spec/validators/multi_value_presence_validator_spec.rb
+++ b/spec/validators/multi_value_presence_validator_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe MultiValuePresenceValidator do
+  let(:validatable) do
+    Class.new do
+      def self.name
+        'Validatable'
+      end
+      include ActiveModel::Validations
+      attr_accessor :contributors
+      validates :contributors, multi_value_presence: true
+    end
+  end
+  subject { validatable.new }
+
+  before do
+    subject.contributors = contributors
+    subject.valid?
+  end
+
+  context 'an empty array' do
+    let(:contributors) { [] }
+    it { expect(subject.errors.messages).to eq contributors: ['can\'t be blank'] }
+  end
+
+  context 'an array with one empty item' do
+    let(:contributors) { ['']  }
+    it { expect(subject.errors.messages).to eq contributors: ['can\'t be blank'] }
+  end
+
+  context 'an array with one empty item and one non-empty' do
+    let(:contributors) { ['', 'Hello']  }
+    it { expect(subject.errors.messages).to eq({}) }
+  end
+
+  context 'an array with first and last elements that are empty' do
+    let(:contributors) { ['', 'Hello', '']  }
+    it { expect(subject.errors.messages).to eq({}) }
+  end
+
+end


### PR DESCRIPTION
Adding multi-value presence validation

Given that we are allowing multi-value for a given attribute, we
need to better handle the presence of that attribute.

Consider:

```
class MyModel
  # Assume this class supports ActiveModel validations
  validate :contributor, presence: true
end

my_model = MyModel.new
my_model.contributor = ['']
my_model.valid?
=> true
```

When in fact we likely mean for it not to be true.

Solution:
    class MyModel
      # Assume this class supports ActiveModel validations
      validate :contributor, multi_value_presence: true
    end

```
my_model = MyModel.new
my_model.contributor = ['']
my_model.valid?
=> false
```

[skip ci]
This commit was an amended commit to include a better commit message.
The build that verifies the actual code changes can be found at:
https://travis-ci.org/projecthydra-labs/curate/builds/25186700
