### PR TITLE
Tweaking how future date validation works

### DIFF
--- a/app/validators/future_date_validator.rb
+++ b/app/validators/future_date_validator.rb
@@ -5,13 +5,13 @@ class FutureDateValidator < ActiveModel::EachValidator
       begin
         if date = value.to_date
           if date <= Date.today
-            record.errors[:embargo_release_date] << "Must be a future date"
+            record.errors[attribute] << "Must be a future date"
           end
         else
-          record.errors[:embargo_release_date] << "Invalid Date Format"
+          record.errors[attribute] << "Invalid Date Format"
         end
-      rescue ArgumentError, NoMethodError
-        record.errors[:embargo_release_date] << "Invalid Date Format"
+      rescue ArgumentError, NoMethodError => e
+        record.errors[attribute] << "Invalid Date Format"
       end
     end
   end

--- a/spec/validators/future_date_validator_spec.rb
+++ b/spec/validators/future_date_validator_spec.rb
@@ -1,35 +1,42 @@
 require 'spec_helper'
 
-class Validatable
-  include ActiveModel::Validations
-  attr_accessor :embargo_release_date
-  validates :embargo_release_date, future_date: true
-end
-
 describe FutureDateValidator do
 
-  subject { Validatable.new }
+  let(:validatable) do
+    Class.new do
+      def self.name
+        'Validatable'
+      end
+      include ActiveModel::Validations
+      attr_accessor :a_date
+      validates :a_date, future_date: true
+    end
+  end
+  subject { validatable.new }
 
-  before { subject.embargo_release_date = embargo_release_date }
+  before do
+    subject.a_date = a_date
+    subject.valid?
+  end
 
   context 'with today as embargo release date' do
-    let(:embargo_release_date) { Date.today.to_s    }
-    it { should have(1).error_on(:embargo_release_date) }
+    let(:a_date) { Date.today.to_s }
+    it { expect(subject.errors.messages).to eq :a_date => ["Must be a future date"] }
   end
 
   context 'with past date as embargo release date' do
-    let(:embargo_release_date) { (Date.today - 2).to_s  }
-    it { should have(1).error_on(:embargo_release_date) }
+    let(:a_date) { (Date.today - 2).to_s  }
+    it { expect(subject.errors.messages).to eq :a_date => ["Must be a future date"] }
   end
 
   context 'invalid date as embargo release date' do
-    let(:embargo_release_date) { "invalid_ date" }
-    it { should have(1).error_on(:embargo_release_date) }
+    let(:a_date) { "invalid_ date" }
+    it { expect(subject.errors.messages).to eq :a_date => ["Invalid Date Format"] }
   end
 
   context 'future date as embargo release date' do
-    let(:embargo_release_date) { (Date.today + 2).to_s    }
-    it { should have(:no).error_on(:embargo_release_date) }
+    let(:a_date) { (Date.today + 2).to_s    }
+    it { expect(subject.errors.messages).to eq({}) }
   end
 
 end


### PR DESCRIPTION
The attribute for validation was hard-coded. I believe this was an
artifact of copying the validator from another repository.

While doing this, I removed the custom class, instead creating a
dynamic class that can be disposed of at the cleanup's leasure.
