### PR TITLE
Fixing embargo when visibility is set via default

### DIFF
--- a/app/repository_models/curation_concern/embargoable.rb
+++ b/app/repository_models/curation_concern/embargoable.rb
@@ -52,12 +52,10 @@ module CurationConcern
     protected :write_embargo_release_date
 
     def embargo_release_date=(value)
-      unless defined?(@embargo_release_date) && @embargo_release_date.nil?
-        @embargo_release_date = begin
-          value.present? ? value.to_date : nil
-        rescue NoMethodError, ArgumentError
-          value
-        end
+      @embargo_release_date = begin
+        value.present? ? value.to_date : nil
+      rescue NoMethodError, ArgumentError
+        value
       end
     end
 

--- a/spec/support/shared/shared_examples_with_access_rights.rb
+++ b/spec/support/shared/shared_examples_with_access_rights.rb
@@ -61,6 +61,19 @@ shared_examples 'with_access_rights' do
   end
 
   describe 'open_access_with_embargo_release_date' do
+    it 'handles when visibility was set via a default' do
+      prepare_subject_for_access_rights_visibility_test!
+      # I am pretending to set a default.
+      # In the request cycle we instantiate the object, then set the attributes
+      # via parameters. If the object sets defaults on instantiation, then
+      # we need to make sure that the visibility patch works.
+      subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+
+      subject.embargo_release_date = 2.days.from_now
+      subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
+      expect(subject).to be_open_access_with_embargo_release_date
+    end
+
     it 'sets visibility' do
       if subject.respond_to?(:embargo_release_date=)
         prepare_subject_for_access_rights_visibility_test!


### PR DESCRIPTION
I am pretending to set a default. In the request cycle we instantiate
the object, then set the attributes via parameters. If the object sets
defaults on instantiation, then this fix ensures that you can set the
embargo release date via the parameters.

Example:

``` ruby
class MyModel
  attribute :visibility, default: 'private'
  attribute :embargo_release_date
end

class MyModelsController
  def create
    @my_model = MyModel.new

    @my_model.attributes = params[:my_model]
  end
end
```

@NOTE - It is unlikely that a default embargo visibility and release
date will properly play together.
