### PR TITLE
Testing and handling Groups Controller error

### DIFF
--- a/app/controllers/hydramata/groups_controller.rb
+++ b/app/controllers/hydramata/groups_controller.rb
@@ -36,6 +36,8 @@ class Hydramata::GroupsController < ApplicationController
       flash[:notice] = "Group created successfully."
       redirect_to hydramata_groups_path
     else
+      @group = Hydramata::Group.new
+      setup_form
       flash[:error] = "Group was not created."
       render action: :new
     end
@@ -56,6 +58,8 @@ class Hydramata::GroupsController < ApplicationController
         redirect_to hydramata_groups_path, notice: "Group updated successfully. You are no longer a member of the Group: #{@group_membership.title}"
       end
     else
+      @group = Hydramata::Group.find(params[:id])
+      setup_form
       flash[:error] = "Group was not updated."
       render action: :edit
     end

--- a/spec/controllers/hydramata/groups_controller_spec.rb
+++ b/spec/controllers/hydramata/groups_controller_spec.rb
@@ -32,6 +32,14 @@ describe Hydramata::GroupsController do
       expect(response).to redirect_to hydramata_groups_path
       expect(flash[:notice]).to eq 'Group created successfully.'
     end
+
+    it "should handle failure" do
+      expect {
+        post :create, hydramata_group: hydramata_group, group_member: {}
+      }.to change{Hydramata::Group.count}.by(0)
+      expect(assigns(:group)).to be_an_instance_of Hydramata::Group
+      expect(response).to render_template('new')
+    end
   end
 
   let(:group) { FactoryGirl.create(:group, user: user, title: "Title 1", description: "Description 1") }
@@ -78,9 +86,17 @@ describe Hydramata::GroupsController do
       reload_group.description.should == hydramata_group["description"]
     end
 
-    let(:another_hydramata_group) { 
-       { "title" => "Group - 1", "description" => "Desc - 1", 
-         "members_attributes" => { "0" => { "id" => person.pid, "_destroy" => ""}, 
+    it "handles failure" do
+      reload_group = Hydramata::Group.find(group.pid)
+      put :update, id: group.pid, hydramata_group: hydramata_group, group_member: {}
+      expect(assigns(:group)).to be_an_instance_of Hydramata::Group
+      expect(response).to render_template('edit')
+      expect(flash[:error]).to eq 'Group was not updated.'
+    end
+
+    let(:another_hydramata_group) {
+       { "title" => "Group - 1", "description" => "Desc - 1",
+         "members_attributes" => { "0" => { "id" => person.pid, "_destroy" => ""},
                                    "1" => { "id" => another_person.pid},
                                    "2" => { "id" => "", "_destroy" => "", "name" => ""}
                                  }


### PR DESCRIPTION
If an error was encountered on the either create or update, the @group
instance variable was not being set and instead would throw an error.
