### PR TITLE
Adjusting Group Membership user comparison

### DIFF
--- a/app/controllers/hydramata/groups_controller.rb
+++ b/app/controllers/hydramata/groups_controller.rb
@@ -68,7 +68,7 @@ class Hydramata::GroupsController < ApplicationController
   end
 
   def setup_form 
-    @group.permissions_attributes = [{name: current_user.email, access: "edit", type: "person"}] if @group.members.blank?
+    @group.permissions_attributes = [{name: current_user.user_key, access: "edit", type: "person"}] if @group.members.blank?
     @group.members << current_user.person if @group.members.blank?
     @group.members.build
   end


### PR DESCRIPTION
By using User#user_key, we are allowing the behavior for implementors
that chose to use a username as the identifier.

@TODO - need to craft the GroupMembership idea. When we iterate on a
Groups#members, we should be providing a proper object that can be
more easily interrogated for its responsibilities.
