### PR TITLE
Fix issue with adding editors to a generic work

### DIFF
--- a/app/views/curation_concern/base/_linked_editors.html.erb
+++ b/app/views/curation_concern/base/_linked_editors.html.erb
@@ -11,7 +11,7 @@
       </label>
     </span>
     <div class="controls">
-      <% prefix = f.object.class.to_s.downcase %>
+      <% prefix = ActiveModel::Naming.singular_route_key(f.object.class) %>
 
       <script id="entry-template" type="text/x-handlebars-template">
         <li class="field-wrapper input-append">
@@ -28,7 +28,7 @@
         </li>
       </script>
       <ul class="listing">
-      
+
       <%= f.fields_for :editors do |editor| %>
         <li class="field-wrapper input-append">
           <%= editor.hidden_field :id %>
@@ -43,7 +43,7 @@
           <span class="field-controls"></span>
         </li>
       <% end %>
-      
+
       </ul>
     </div>
   </div>

--- a/spec/views/curation_concern/base/_form.html.erb_spec.rb
+++ b/spec/views/curation_concern/base/_form.html.erb_spec.rb
@@ -37,6 +37,9 @@ describe 'curation_concern/base/_form.html.erb' do
     it 'should have group help text' do
       expect(rendered).to have_text(t('sufia.work.editor.group.help'))
     end
+    it 'should have a valid prefix for editor name fields' do
+      expect(rendered).to have_text('generic_work_editors_attributes_{{index}}_id')
+    end
   end
 
   context 'Edit Work' do


### PR DESCRIPTION
Adding editors to a generic work suffered from the same problem
as https://github.com/projecthydra-labs/curate/pull/526.  So we
implemented the same fix for the prefix (using "generic_work"
instead of "genericwork")

HYDRASIR-529 #close
