### PR TITLE
Add button attribute to all add/remove button tags

### DIFF
--- a/app/assets/javascripts/curate/link_groups.js.coffee
+++ b/app/assets/javascripts/curate/link_groups.js.coffee
@@ -5,8 +5,8 @@
   _settings =
     default: 'cool!'
     
-  _remover = $("<button class=\"btn btn-danger remove\"><i class=\"icon-white icon-minus\"></i><span>Remove</span></button>")
-  _adder   = $("<button class=\"btn btn-success add\"><i class=\"icon-white icon-plus\"></i><span>Add</span></button>")
+  _remover = $("<button type=\"button\" class=\"btn btn-danger remove\"><i class=\"icon-white icon-minus\"></i><span>Remove</span></button>")
+  _adder   = $("<button type=\"button\" class=\"btn btn-success add\"><i class=\"icon-white icon-plus\"></i><span>Add</span></button>")
   
  
   # This is your public API (no leading underscore, see?)

--- a/app/assets/javascripts/curate/link_users.js.coffee
+++ b/app/assets/javascripts/curate/link_users.js.coffee
@@ -5,8 +5,8 @@
   _settings =
     default: 'cool!'
     
-  _remover = $("<button class=\"btn btn-danger remove\"><i class=\"icon-white icon-minus\"></i><span>Remove</span></button>")
-  _adder   = $("<button class=\"btn btn-success add\"><i class=\"icon-white icon-plus\"></i><span>Add</span></button>")
+  _remover = $("<button type=\"button\" class=\"btn btn-danger remove\"><i class=\"icon-white icon-minus\"></i><span>Remove</span></button>")
+  _adder   = $("<button type=\"button\" class=\"btn btn-success add\"><i class=\"icon-white icon-plus\"></i><span>Add</span></button>")
   
  
   # This is your public API (no leading underscore, see?)

--- a/app/assets/javascripts/manage_repeating_fields.js
+++ b/app/assets/javascripts/manage_repeating_fields.js
@@ -15,8 +15,8 @@
       $('.field-wrapper', this.element).addClass("input-append");
 
       this.controls = $("<span class=\"field-controls\">");
-      this.remover  = $("<button class=\"btn btn-danger remove\"><i class=\"icon-white icon-minus\"></i><span>Remove</span></button>");
-      this.adder    = $("<button class=\"btn btn-success add\"><i class=\"icon-white icon-plus\"></i><span>Add</span></button>");
+      this.remover  = $("<button type=\"button\" class=\"btn btn-danger remove\"><i class=\"icon-white icon-minus\"></i><span>Remove</span></button>");
+      this.adder    = $("<button type=\"button\" class=\"btn btn-success add\"><i class=\"icon-white icon-plus\"></i><span>Add</span></button>");
 
       $('.field-wrapper', this.element).append(this.controls);
       $('.field-wrapper:not(:last-child) .field-controls', this.element).append(this.remover);
@@ -72,3 +72,4 @@
     }
   });
 })(jQuery);
+

--- a/app/views/curation_concern/base/_linked_editors.html.erb
+++ b/app/views/curation_concern/base/_linked_editors.html.erb
@@ -17,14 +17,14 @@
         <li class="field-wrapper input-append">
           <input id="<%=prefix %>_editors_attributes_{{index}}_id" name="<%=prefix %>[editors_attributes][{{index}}][id]" type="hidden" value="" />
           <input class="input-xlarge autocomplete-users" data-url="/people" id="<%=prefix %>_editors_attributes_{{index}}_name" name="<%=prefix %>[editors_attributes][{{index}}][name]" type="text" value="" />
-          <span class="field-controls"><button class="btn btn-success add"><i class="icon-white icon-plus"></i><span>Add</span></button></span>
+          <span class="field-controls"><button type="button" class="btn btn-success add"><i class="icon-white icon-plus"></i><span>Add</span></button></span>
         </li>
       </script>
       <script id="existing-user-template" type="text/x-handlebars-template">
         <li class="field-wrapper input-append">
           <span class="linked-user"><a href="/people/{{value}}" target="_new">{{label}}</a></span>
           <input type="hidden" name="<%=prefix %>[editors_attributes][{{index}}][id]" value="{{value}}">
-          <span class="field-controls"><button class="btn btn-danger remove"><i class="icon-white icon-minus"></i><span>Remove</span></button></span>
+          <span class="field-controls"><button type="button" class="btn btn-danger remove"><i class="icon-white icon-minus"></i><span>Remove</span></button></span>
         </li>
       </script>
       <ul class="listing">
@@ -48,4 +48,5 @@
     </div>
   </div>
 </fieldset>
+
 

--- a/app/views/curation_concern/base/_linked_groups.html.erb
+++ b/app/views/curation_concern/base/_linked_groups.html.erb
@@ -15,18 +15,18 @@
         <li class="field-wrapper input-append">
           <input id="<%=prefix %>_editor_groups_attributes_{{index}}_id" name="<%=prefix %>[editor_groups_attributes][{{index}}][id]" type="hidden" value="" />
           <input class="input-xlarge autocomplete-groups" data-url="/hydramata/groups" id="<%=prefix %>_editor_groups_attributes_{{index}}_title" name="<%=prefix %>[editor_groups_attributes][{{index}}][title]" type="text" value="" />
-          <span class="field-controls"><button class="btn btn-success add"><i class="icon-white icon-plus"></i><span>Add</span></button></span>
+          <span class="field-controls"><button type="button" class="btn btn-success add"><i class="icon-white icon-plus"></i><span>Add</span></button></span>
         </li>
       </script>
       <script id="existing-group-template" type="text/x-handlebars-template">
         <li class="field-wrapper input-append">
           <span class="linked-group"><a href="/hydramata/groups/{{value}}" target="_new">{{label}}</a></span>
           <input type="hidden" name="<%=prefix %>[editor_groups_attributes][{{index}}][id]" value="{{value}}">
-          <span class="field-controls"><button class="btn btn-danger remove"><i class="icon-white icon-minus"></i><span>Remove</span></button></span>
+          <span class="field-controls"><button type="button" class="btn btn-danger remove"><i class="icon-white icon-minus"></i><span>Remove</span></button></span>
         </li>
       </script>
       <ul class="listing">
-      
+
       <%= f.fields_for :editor_groups do |group| %>
         <li class="field-wrapper input-append">
           <%= group.hidden_field :id %>
@@ -40,8 +40,9 @@
           <span class="field-controls"></span>
         </li>
       <% end %>
-      
+
       </ul>
     </div>
   </div>
 </fieldset>
+

--- a/app/views/curation_concern/base/_persons_edit_access.html.erb
+++ b/app/views/curation_concern/base/_persons_edit_access.html.erb
@@ -13,14 +13,14 @@
       <li class="field-wrapper input-append">
         <input id="<%=prefix %>_editors_{{index}}_id" name="<%=prefix %>[editors][{{index}}][id]" type="hidden" value="" />
         <input class="input-xlarge autocomplete-users" data-url="/people" id="<%=prefix %>_editors_{{index}}_name" name="<%=prefix %>[editors][{{index}}][name]" type="text" value="" />
-        <span class="field-controls"><button class="btn btn-success add"><i class="icon-white icon-plus"></i><span>Add</span></button></span>
+        <span class="field-controls"><button type="button" class="btn btn-success add"><i class="icon-white icon-plus"></i><span>Add</span></button></span>
       </li>
     </script>
     <script id="existing-user-template" type="text/x-handlebars-template">
       <li class="field-wrapper input-append">
         <span class="linked-user"><a href="/people/{{value}}" target="_new">{{label}}</a></span>
         <input type="hidden" name="<%=prefix %>[editors][{{index}}][id]" value="{{value}}">
-        <span class="field-controls"><button class="btn btn-danger remove"><i class="icon-white icon-minus"></i><span>Remove</span></button></span>
+        <span class="field-controls"><button type="button" class="btn btn-danger remove"><i class="icon-white icon-minus"></i><span>Remove</span></button></span>
       </li>
     </script>
     <ul class="listing">
@@ -41,4 +41,5 @@
     </ul>
   </div>
 </div>
+
 

--- a/app/views/hydramata/groups/_linked_members.html.erb
+++ b/app/views/hydramata/groups/_linked_members.html.erb
@@ -21,7 +21,7 @@
           <div class="span4">
             <input class="input-xlarge autocomplete-users" data-url="/people" id="<%=prefix %>_members_attributes_{{index}}_name" name="<%=prefix %>[members_attributes][{{index}}][name]" type="text" value="" />
             <span class="field-controls">
-              <button class="btn btn-success add">
+              <button type="button" class="btn btn-success add">
                 <i class="icon-white icon-plus"></i>
                 <span>Add</span>
               </button>
@@ -43,7 +43,7 @@
             </span>
             <input type="hidden" name="<%=prefix %>[members_attributes][{{index}}][id]" value="{{value}}">
             <span class="field-controls">
-              <button class="btn btn-danger remove">
+              <button type="button" class="btn btn-danger remove">
                 <i class="icon-white icon-minus"></i>
                 <span>Remove</span>
               </button>
@@ -99,3 +99,4 @@
     </ul>
   </div>
 </div>
+


### PR DESCRIPTION
The browser was activating add/remove buttons when the user pressed
enter.  Adding the type="button" to button tags prevents the user
from accidentally removing items from the multi-valued list.

HYDRASIR-535 #close
