### PR TITLE
Set the file path correctly for predicate_mapping file

### DIFF
--- a/lib/generators/curate/application_template.rb
+++ b/lib/generators/curate/application_template.rb
@@ -11,7 +11,7 @@ def yes_with_banner?(message, banner = "*" * 80)
 end
 def source_paths
   Array(super) +
-      [File.join(File.expand_path(File.dirname(__FILE__)),'predicate_mapping')]
+      [File.join(File.expand_path(File.dirname(__FILE__)))]
 end
 
 
@@ -22,7 +22,7 @@ with_git("Adding curate gem") do
 end
 
 
-copy_file 'predicate_mappings.yml', 'config/predicate_mappings.yml'
+copy_file 'templates/predicate_mappings.yml', 'config/predicate_mappings.yml'
 
 
 HELPFUL_DEVELOPMENT_TOOLS =


### PR DESCRIPTION
This was creating an issue when trying to install using cmd:

rails new my_curate_application -m https://raw.github.com/projecthydra/curate/develop/lib/generators/curate/application_template.rb
