### PR TITLE
Setting rspec ecosystem to v2.x

### DIFF
--- a/curate.gemspec
+++ b/curate.gemspec
@@ -49,9 +49,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'browse-everything'
   s.add_dependency 'httparty'
   s.add_development_dependency 'sqlite3'
-  s.add_development_dependency "rspec-rails"
-  s.add_development_dependency "factory_girl_rails"
-  s.add_development_dependency 'rspec-html-matchers'
+  s.add_development_dependency "rspec-rails", '~> 2.14.0'
+  s.add_development_dependency "factory_girl_rails", '~>4.2.0'
+  s.add_development_dependency 'rspec-html-matchers', '~> 0.4'
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'jettywrapper'

--- a/lib/generators/curate/work/templates/factory.rb.erb
+++ b/lib/generators/curate/work/templates/factory.rb.erb
@@ -18,6 +18,7 @@ FactoryGirl.define do
     before(:create) { |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
       work.contributor << "Some Body"
+      work.creator << "Me"
     }
 
     factory :private_<%= singular_table_name %> do

--- a/lib/generators/curate/work/templates/model.rb.erb
+++ b/lib/generators/curate/work/templates/model.rb.erb
@@ -30,10 +30,10 @@ class <%= class_name %> < ActiveFedora::Base
   attribute :date_uploaded,  datastream: :descMetadata, multiple: false
   attribute :date_modified,  datastream: :descMetadata, multiple: false
   attribute :available,      datastream: :descMetadata, multiple: false
-  attribute :creator,        datastream: :descMetadata, multiple: false
   attribute :content_format, datastream: :descMetadata, multiple: false
   attribute :identifier,     datastream: :descMetadata, multiple: false
 
+  attribute :creator,        datastream: :descMetadata, multiple: true
   attribute :contributor,            datastream: :descMetadata, multiple: true
   attribute :publisher,              datastream: :descMetadata, multiple: true
   attribute :bibliographic_citation, datastream: :descMetadata, multiple: true

--- a/spec/factories/generic_works_factory.rb
+++ b/spec/factories/generic_works_factory.rb
@@ -12,6 +12,7 @@ FactoryGirl.define do
       work.apply_depositor_metadata(evaluator.user.user_key)
       work.owner = evaluator.user.user_key
       work.contributor << "Some Body"
+      work.creator = "The Creator"
     }
 
     factory :private_generic_work do

--- a/spec/lib/generators/curate/work/work_generator_spec.rb
+++ b/spec/lib/generators/curate/work/work_generator_spec.rb
@@ -14,7 +14,7 @@ at_exit do
   end
 end
 
-response = Curate::WorkGenerator.start(%W(spam --force --doi=true), destination_root: Rails.root)
+response = Curate::WorkGenerator.start(%W(spam --force), destination_root: Rails.root)
 
 sleep(2) if ENV['TRAVIS'] # Because the generator is not completing
 

--- a/spec/repository_models/generic_work_spec.rb
+++ b/spec/repository_models/generic_work_spec.rb
@@ -7,7 +7,6 @@ describe GenericWork do
   it_behaves_like 'is_embargoable'
   it_behaves_like 'has_dc_metadata'
   it_behaves_like 'has_common_solr_fields'
-  it_behaves_like 'remotely_identified', :doi
 
   it { should have_unique_field(:available) }
   it { should have_unique_field(:human_readable_type) }

--- a/tasks/curate_tasks.rake
+++ b/tasks/curate_tasks.rake
@@ -48,10 +48,11 @@ task :generate do
       gem 'capybara'
       gem 'coveralls', require: false
       gem 'database_cleaner', '< 1.1.0'
-      gem 'factory_girl_rails'
+      gem 'factory_girl_rails', '~> 4.2.0'
+      gem 'rspec', '~> 2.14.0'
       gem 'launchy'
       gem 'poltergeist'
-      gem 'rspec-html-matchers'
+      gem 'rspec-html-matchers', '~> 0.4.0'
       gem 'simplecov', require: false
       gem 'test_after_commit'
       gem 'timecop'


### PR DESCRIPTION
With RSpec 3 being released, the RSpec API may have changed. This is
a conjecture on why the specs are failing.
