### PR TITLE
Implements clamav functionality in curate_fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ env:
 
 script: "rake ci"
 
-notifications:
-  irc: "irc.freenode.org#ndlib"
-
 bundler_args: --without headless
 
 before_install:

--- a/spec/controllers/curation_concern/generic_files_controller_spec.rb
+++ b/spec/controllers/curation_concern/generic_files_controller_spec.rb
@@ -31,6 +31,7 @@ describe CurationConcern::GenericFilesController do
     end
   end
 
+
   describe '#create' do
     let(:actor) { double('actor') }
     let(:actors_action) { :create }
@@ -42,6 +43,8 @@ describe CurationConcern::GenericFilesController do
       actor.should_receive(actors_action).and_return(true)
       actor
     }
+
+    let(:client) { ClamAV.instance }
 
     it 'redirects to parent when successful' do
       sign_in(user)
@@ -96,6 +99,13 @@ describe CurationConcern::GenericFilesController do
       response.status.should == 422
     end
 
+    it "should call virus check" do
+      GenericFile.stub(:create).and_return({})
+      test_file = File.expand_path('../../fixtures/files/image.png', __FILE__)
+      client.loaddb()
+      client.scanfile(test_file).should be_a_kind_of(Fixnum)
+    end
+
   end
 
   describe '#edit' do
@@ -139,6 +149,7 @@ describe CurationConcern::GenericFilesController do
         )
       )
     end
+
   end
 
 

--- a/tasks/curate_tasks.rake
+++ b/tasks/curate_tasks.rake
@@ -43,6 +43,7 @@ task :generate do
     gem 'curate', :path=>'../../../#{File.expand_path('../../', __FILE__).split('/').last}'
     gem 'kaminari', github: 'harai/kaminari', branch: 'route_prefix_prototype'
     gem 'browse-everything'
+    gem 'clamav'
 
     group :test do
       gem 'capybara'


### PR DESCRIPTION
Scan occurs in generic_files_controller and generic_works_controller.

Will need to confirm use with browse_everything.
